### PR TITLE
Feature/111 cosmosdb optimize indexes

### DIFF
--- a/src/Storage/Repository/ApplicationRepository.cs
+++ b/src/Storage/Repository/ApplicationRepository.cs
@@ -39,12 +39,14 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="generalSettings">the general settings</param>
         /// <param name="logger">dependency injection of logger</param>
         /// <param name="memoryCache">the memory cache</param>
+        /// <param name="cosmosClient">CosmosClient singleton</param>
         public ApplicationRepository(
             IOptions<AzureCosmosSettings> cosmosSettings,
             IOptions<GeneralSettings> generalSettings,
             ILogger<ApplicationRepository> logger,
-            IMemoryCache memoryCache)
-            : base(CollectionId, PartitionKey, cosmosSettings)
+            IMemoryCache memoryCache,
+            CosmosClient cosmosClient)
+            : base(CollectionId, PartitionKey, cosmosSettings, cosmosClient)
         {
             _logger = logger;
 

--- a/src/Storage/Repository/BaseRepository.cs
+++ b/src/Storage/Repository/BaseRepository.cs
@@ -1,6 +1,5 @@
 namespace Altinn.Platform.Storage.Repository
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -20,11 +19,12 @@ namespace Altinn.Platform.Storage.Repository
         private readonly string _collectionId;
         private readonly string _partitionKey;
         private readonly AzureCosmosSettings _cosmosSettings;
+        private readonly CosmosClient _cosmosClient;
 
         /// <summary>
         /// The document collection.
         /// </summary>
-        protected Container Container { get; private set; }
+        protected Container Container { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseRepository"/> class.
@@ -32,12 +32,18 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="collectionId">The ID of the collection.</param>
         /// <param name="partitionKey">The PK of the collection.</param>
         /// <param name="cosmosSettings">The settings object.</param>
-        public BaseRepository(string collectionId, string partitionKey, IOptions<AzureCosmosSettings> cosmosSettings)
+        /// <param name="cosmosClient">CosmosClient singleton</param>
+        public BaseRepository(
+            string collectionId, 
+            string partitionKey, 
+            IOptions<AzureCosmosSettings> cosmosSettings, 
+            CosmosClient cosmosClient)
         {
             _collectionId = collectionId;
             _partitionKey = partitionKey;
             _cosmosSettings = cosmosSettings.Value;
             _databaseId = _cosmosSettings.Database;
+            _cosmosClient = cosmosClient;
         }
 
         /// <inheritdoc/>
@@ -54,14 +60,7 @@ namespace Altinn.Platform.Storage.Repository
 
         private async Task<Container> CreateDatabaseAndCollection(CancellationToken cancellationToken)
         {
-            CosmosClientOptions options = new()
-            {
-                ConnectionMode = ConnectionMode.Gateway,
-            };
-
-            CosmosClient client = new CosmosClient(_cosmosSettings.EndpointUri, _cosmosSettings.PrimaryKey, options);
-
-            Database db = await client.CreateDatabaseIfNotExistsAsync(_databaseId, cancellationToken: cancellationToken);
+            Database db = await _cosmosClient.CreateDatabaseIfNotExistsAsync(_databaseId, cancellationToken: cancellationToken);
 
             Container container = await db.CreateContainerIfNotExistsAsync(_collectionId, _partitionKey, cancellationToken: cancellationToken);
             return container;

--- a/src/Storage/Repository/BaseRepository.cs
+++ b/src/Storage/Repository/BaseRepository.cs
@@ -63,7 +63,7 @@ namespace Altinn.Platform.Storage.Repository
             Database db = await _cosmosClient.CreateDatabaseIfNotExistsAsync(_databaseId, cancellationToken: cancellationToken);
 
             Container container = await db.CreateContainerIfNotExistsAsync(_collectionId, _partitionKey, cancellationToken: cancellationToken);
-            var indexUpdated = await this.VerifyIndexPolicy(container);
+            var indexUpdated = await SetIndexPolicy(container);
             return container;
         }
 
@@ -71,7 +71,7 @@ namespace Altinn.Platform.Storage.Repository
         /// Verifies that each container has the correct index policy.
         /// </summary>
         /// <returns>True if container required an index policy update</returns>        
-        protected virtual async Task<bool> VerifyIndexPolicy(Container container)
+        protected virtual async Task<bool> SetIndexPolicy(Container container)
         {
             var containerResponse = await container.ReadContainerAsync();
 

--- a/src/Storage/Repository/DataRepository.cs
+++ b/src/Storage/Repository/DataRepository.cs
@@ -40,12 +40,14 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="cosmosSettings">the configuration settings for azure cosmos database</param>
         /// <param name="storageConfiguration">the storage configuration for azure blob storage</param>
         /// <param name="logger">The logger to use when writing to logs.</param>
+        /// <param name="cosmosClient">CosmosClient singleton</param>
         public DataRepository(
             ISasTokenProvider sasTokenProvider,
             IOptions<AzureCosmosSettings> cosmosSettings,
             IOptions<AzureStorageConfiguration> storageConfiguration,
-            ILogger<DataRepository> logger)
-            : base(CollectionId, PartitionKey, cosmosSettings)
+            ILogger<DataRepository> logger,
+            CosmosClient cosmosClient)
+            : base(CollectionId, PartitionKey, cosmosSettings, cosmosClient)
         {
             _storageConfiguration = storageConfiguration.Value;
             _sasTokenProvider = sasTokenProvider;

--- a/src/Storage/Repository/InstanceEventRepository.cs
+++ b/src/Storage/Repository/InstanceEventRepository.cs
@@ -128,5 +128,24 @@ namespace Altinn.Platform.Storage.Repository
 
             return deletedEventsCount;
         }
+
+        /// <inheritdoc/>
+        protected override async Task<bool> SetIndexPolicy(Container container)
+        {
+            var containerResponse = await container.ReadContainerAsync();
+            var existingPolicy = containerResponse.Resource.IndexingPolicy;
+
+            var newPolicy = new IndexingPolicy();
+            newPolicy.IndexingMode = IndexingMode.Consistent;
+            newPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/*" });
+            newPolicy.IncludedPaths.Add(new IncludedPath { Path = "/instanceId/?" });
+
+            containerResponse.Resource.IndexingPolicy = newPolicy;
+
+            var result = await container.ReplaceContainerAsync(containerResponse.Resource);
+            Container = result.Container;
+
+            return true;
+        }
     }
 }

--- a/src/Storage/Repository/InstanceEventRepository.cs
+++ b/src/Storage/Repository/InstanceEventRepository.cs
@@ -25,8 +25,9 @@ namespace Altinn.Platform.Storage.Repository
         /// Initializes a new instance of the <see cref="InstanceEventRepository"/> class
         /// </summary>
         /// <param name="cosmosSettings">The configuration settings for cosmos database</param>
-        public InstanceEventRepository(IOptions<AzureCosmosSettings> cosmosSettings)
-            : base(CollectionId, PartitionKey, cosmosSettings)
+        /// <param name="cosmosClient">CosmosClient singleton</param>
+        public InstanceEventRepository(IOptions<AzureCosmosSettings> cosmosSettings, CosmosClient cosmosClient)
+            : base(CollectionId, PartitionKey, cosmosSettings, cosmosClient)
         {
         }
 

--- a/src/Storage/Repository/InstanceRepository.cs
+++ b/src/Storage/Repository/InstanceRepository.cs
@@ -33,11 +33,13 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="cosmosSettings">the configuration settings for cosmos database</param>
         /// <param name="logger">the logger</param>
         /// <param name="dataRepository">the data repository to fetch data elements from</param>
+        /// <param name="cosmosClient">CosmosClient singleton</param>
         public InstanceRepository(
             IOptions<AzureCosmosSettings> cosmosSettings,
             ILogger<InstanceRepository> logger,
-            IDataRepository dataRepository)
-            : base(CollectionId, PartitionKey, cosmosSettings)
+            IDataRepository dataRepository, 
+            CosmosClient cosmosClient) 
+            : base(CollectionId, PartitionKey, cosmosSettings, cosmosClient)
         {
             _logger = logger;
             _dataRepository = dataRepository;

--- a/src/Storage/Repository/TextRepository.cs
+++ b/src/Storage/Repository/TextRepository.cs
@@ -33,12 +33,14 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="generalSettings">the general configurations settings</param>
         /// <param name="logger">the logger</param>
         /// <param name="memoryCache">the memory cache</param>
+        /// <param name="cosmosClient">CosmosClient singleton</param>
         public TextRepository(
             IOptions<AzureCosmosSettings> cosmosSettings,
             IOptions<GeneralSettings> generalSettings,
             ILogger<ITextRepository> logger,
-            IMemoryCache memoryCache)
-            : base(CollectionId, PartitionKey, cosmosSettings)
+            IMemoryCache memoryCache, 
+            CosmosClient cosmosClient) 
+            : base(CollectionId, PartitionKey, cosmosSettings, cosmosClient)
         {
             _logger = logger;
 


### PR DESCRIPTION
Optimize index configuration for InstanceEvents

## Description
Only index columns used in queries, to save RUs on create and update operations.

## Related Issue(s)
- #111 

## Verification
- [ ] Code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
