### PR TITLE
Retrieve dataElements in parallel to save approx 90% RU

### DIFF
--- a/src/Storage/Repository/DataRepository.cs
+++ b/src/Storage/Repository/DataRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -154,6 +155,45 @@ namespace Altinn.Platform.Storage.Repository
             {
                 FeedResponse<DataElement> response = await query.ReadNextAsync();
                 dataElements.AddRange(response);
+            }
+
+            return dataElements;
+        }
+
+        /// <inheritdoc/>
+        public async Task<Dictionary<string, List<DataElement>>> ReadAllForMultiple(List<string> instanceGuids)
+        {
+            Dictionary<string, List<DataElement>> dataElements = new();
+            if (instanceGuids == null || instanceGuids.Count == 0)
+            {
+                return dataElements;
+            }
+
+            foreach (var guidString in instanceGuids)
+            {
+                dataElements[guidString] = new List<DataElement>();
+            }
+
+            QueryRequestOptions options = new QueryRequestOptions()
+            {
+                MaxBufferedItemCount = 0,
+                MaxConcurrency = -1,
+
+                // Do not set PartitionKey as we are querying across all partitions
+            };
+
+            FeedIterator<DataElement> query = Container
+                .GetItemLinqQueryable<DataElement>(requestOptions: options)
+                .Where(x => instanceGuids.Contains(x.Id))
+                .ToFeedIterator();
+
+            while (query.HasMoreResults)
+            {
+                FeedResponse<DataElement> response = await query.ReadNextAsync();
+                foreach (DataElement dataElement in response)
+                {
+                    dataElements[dataElement.InstanceGuid].Add(dataElement);
+                }
             }
 
             return dataElements;

--- a/src/Storage/Repository/IDataRepository.cs
+++ b/src/Storage/Repository/IDataRepository.cs
@@ -45,6 +45,13 @@ namespace Altinn.Platform.Storage.Repository
         Task<List<DataElement>> ReadAll(Guid instanceGuid);
 
         /// <summary>
+        /// Gets all data elements for a given instance
+        /// </summary>
+        /// <param name="instanceGuids">the list of instance guids to return data elements for</param>
+        /// <returns>list of data elements</returns>
+        Task<Dictionary<string, List<DataElement>>> ReadAllForMultiple(List<string> instanceGuids);
+
+        /// <summary>
         /// Creates a dataElement into the repository
         /// </summary>
         /// <param name="dataElement">the data element to insert</param>

--- a/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
@@ -69,6 +69,30 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return await Task.FromResult(dataElements);
         }
 
+        public async Task<Dictionary<string, List<DataElement>>> ReadAllForMultiple(List<string> instanceGuids)
+        {
+            Dictionary<string, List<DataElement>> dataElements = new();
+            foreach (var instanceGuid in instanceGuids)
+            {
+                dataElements[instanceGuid] = new List<DataElement>();
+            }
+
+            string dataElementsPath = GetDataElementsPath();
+
+            string[] dataElementPaths = Directory.GetFiles(dataElementsPath);
+            foreach (string elementPath in dataElementPaths)
+            {
+                string content = File.ReadAllText(elementPath);
+                DataElement dataElement = (DataElement)JsonConvert.DeserializeObject(content, typeof(DataElement));
+                if (instanceGuids.Contains(dataElement.InstanceGuid))
+                {
+                    dataElements[dataElement.InstanceGuid].Add(dataElement);
+                }
+            }
+
+            return await Task.FromResult(dataElements);
+        }
+
         public async Task<Stream> ReadDataFromStorage(string org, string blobStoragePath)
         {
             string dataPath = Path.Combine(GetDataBlobPath(), blobStoragePath);
@@ -99,6 +123,6 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
         {
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(DataRepositoryMock).Assembly.Location).LocalPath);
             return Path.Combine(unitTestFolder, "..", "..", "..", "data", "blob");
-        }
+        }        
     }
 }


### PR DESCRIPTION
Instead of requesting dataElements individually for each instance, define a cross-partition query that retrieves dataElements for multiple instances in a single query.

## Related Issue(s)
- #124 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

