### PR TITLE
Add FileScanResult and configuration property

### DIFF
--- a/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
+++ b/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>3.11.0</Version>
-    <AssemblyVersion>3.11.0.0</AssemblyVersion>
+    <Version>3.12.0</Version>
+    <AssemblyVersion>3.12.0.0</AssemblyVersion>
     <PackageId>Altinn.Platform.Storage.Interface</PackageId>
     <PackageTags>Altinn;Studio;Platform;Storage;Models</PackageTags>
     <Description>

--- a/src/Storage.Interface/Enums/FileScanResult.cs
+++ b/src/Storage.Interface/Enums/FileScanResult.cs
@@ -1,0 +1,23 @@
+﻿namespace Altinn.Platform.Storage.Interface.Enums
+{
+    /// <summary>
+    /// Represents different scanning results for when files are being scanned for malware.
+    /// </summary>
+    public enum FileScanResult
+    {
+        /// <summary>
+        /// The scan status of the file is pending. This is the default value.
+        /// </summary>
+        Pending,
+
+        /// <summary>
+        /// The file scan did not find any malware in the file.
+        /// </summary>
+        Clean,
+
+        /// <summary>
+        /// The file scan found malware in the file.
+        /// </summary>
+        Infected
+    }
+}

--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Altinn.Platform.Storage.Interface.Enums;
+
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Storage.Interface.Models
@@ -89,6 +91,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "deleteStatus")]
         public DeleteStatus DeleteStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets the result of a file scan of the blob represented by this data element.
+        /// </summary>
+        [JsonProperty(PropertyName = "fileScanResult")]
+        public FileScanResult FileScanResult { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/Storage.Interface/Models/DataType.cs
+++ b/src/Storage.Interface/Models/DataType.cs
@@ -93,5 +93,11 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "enablePdfCreation")]
         public bool EnablePdfCreation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether file uploaded to this data type should be scanned for malware. Default value is <c>false</c>.
+        /// </summary>
+        [JsonProperty(PropertyName = "enableFileScan")]
+        public bool EnableFileScan { get; set; }
     }
 }


### PR DESCRIPTION
## Description
Adding an enum FileScanResult to describe the result of a file scan.
Adding FileScanResult property to DataElement
Adding EnableFileScan configuration to DataType

## Related Issue(s)
- https://github.com/Altinn/altinn-file-scan/issues/7
