### PR TITLE
Avoid reading data elements twice for operations create and update.

### DIFF
--- a/src/Storage/Repository/InstanceRepository.cs
+++ b/src/Storage/Repository/InstanceRepository.cs
@@ -53,8 +53,7 @@ namespace Altinn.Platform.Storage.Repository
             instance.Id ??= Guid.NewGuid().ToString();
 
             Instance instanceStored = await Container.CreateItemAsync<Instance>(instance, new PartitionKey(instance.InstanceOwner.PartyId));
-
-            await PostProcess(instanceStored);
+            instanceStored.Id = $"{instanceStored.InstanceOwner.PartyId}/{instanceStored.Id}";
 
             return instanceStored;
         }
@@ -537,11 +536,13 @@ namespace Altinn.Platform.Storage.Repository
         /// <inheritdoc/>
         public async Task<Instance> Update(Instance item)
         {
+            List<DataElement> dataElements = item.Data;
             PreProcess(item);
 
             Instance instance = await Container.UpsertItemAsync<Instance>(item, new PartitionKey(item.InstanceOwner.PartyId));
 
-            await PostProcess(instance);
+            instance.Data = dataElements;
+            instance.Id = $"{instance.InstanceOwner.PartyId}/{instance.Id}";
 
             return instance;
         }


### PR DESCRIPTION
## Description
Avoid reading data elements twice for operations create and update.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
