### PR TITLE
Add ContentHash to DataElement model, bump versions.

### DIFF
--- a/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
+++ b/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>3.14.0</Version>
-    <AssemblyVersion>3.14.0.0</AssemblyVersion>
+    <Version>3.15.0</Version>
+    <AssemblyVersion>3.15.0.0</AssemblyVersion>
     <PackageId>Altinn.Platform.Storage.Interface</PackageId>
     <PackageTags>Altinn;Studio;Platform;Storage;Models</PackageTags>
     <Description>

--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Storage.Interface.Models
         public long Size { get; set; }
 
         /// <summary>
-        /// Gets or sets the computed MD5 hash value of the blob.
+        /// Gets or sets the computed MD5 hash value of the blob. (Base64 encoded string, not the more common hex encoding)
         /// </summary>
         [JsonProperty(PropertyName = "contentHash")]
         public string ContentHash { get; set; }

--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -66,6 +66,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         public long Size { get; set; }
 
         /// <summary>
+        /// Gets or sets the computed MD5 hash value of the blob.
+        /// </summary>
+        [JsonProperty(PropertyName = "contentHash")]
+        public string ContentHash { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the element can be updated.
         /// </summary>
         [JsonProperty(PropertyName = "locked")]


### PR DESCRIPTION
One more adjustment to DataElement model, saving base64 encoded MD5 content hash value computed by Azure Blob Storage on successful upload.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
