### PR TITLE
Remove duplcate instance owner party id.

### DIFF
--- a/src/Storage/Services/DataService.cs
+++ b/src/Storage/Services/DataService.cs
@@ -30,7 +30,7 @@ namespace Altinn.Platform.Storage.Services
             {
                 FileScanRequest fileScanRequest = new()
                 {
-                    InstanceId = $"{instance.InstanceOwner.PartyId}/{instance.Id}",
+                    InstanceId = instance.Id,
                     DataElementId = dataElement.Id,
                     BlobStoragePath = dataElement.BlobStoragePath,
                     Filename = dataElement.Filename,

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -39,7 +39,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             DataService target = new DataService(fileScanMock.Object);
 
-            Instance instance = new Instance { Id = "guid", InstanceOwner = new InstanceOwner { PartyId = "343243" } };
+            Instance instance = new Instance { Id = "343243/guid" };
             DataType dataType = new DataType { EnableFileScan = true };
             DataElement dataElement = new DataElement { };
 


### PR DESCRIPTION
## Description
Remove the unnecessary concatination of InstanceOwnerPartyId and InstanceId.

