### PR TITLE
Change Cosmos connection mode from Gateway to Direct

### DIFF
--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -239,7 +239,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     AzureCosmosSettings cosmosSettings = config.GetSection("AzureCosmosSettings").Get<AzureCosmosSettings>();
     CosmosClientOptions options = new()
     {
-        ConnectionMode = ConnectionMode.Gateway,
+        ConnectionMode = ConnectionMode.Direct,        
         GatewayModeMaxConnectionLimit = 100
     };
     CosmosClient cosmosClient = new(cosmosSettings.EndpointUri, cosmosSettings.PrimaryKey, options);


### PR DESCRIPTION
During performance testing of FileScan component, we identified potentially high latency between Storage and Cosmos DB. 

Microsoft recommends using Direct connection mode.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
