### PR TITLE
Disable Azure Functions clean output 

### DIFF
--- a/src/DataCleanup/Altinn.Platform.Storage.DataCleanup.csproj
+++ b/src/DataCleanup/Altinn.Platform.Storage.DataCleanup.csproj
@@ -4,6 +4,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!-- SonarCloud needs this -->
     <ProjectGuid>{3F69C9C9-D602-490C-B2BA-A5FB27E363EE}</ProjectGuid>
+	  <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.15.0" />


### PR DESCRIPTION
Azure Function projects apparently have a special build output clean stage that ends up removing certain build artifacts, including System.Json.Text.


## Description

Background information available here:
https://github.com/Azure/azure-functions-host/issues/7061
https://github.com/bryanknox/AzureFunctionsOpenIDConnectAuthSample/issues/27

## Related Issue(s)
- #148 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green
