### PR TITLE
Add null check when retrieving instances.

### DIFF
--- a/src/DataCleanup/Services/CosmosService.cs
+++ b/src/DataCleanup/Services/CosmosService.cs
@@ -244,15 +244,20 @@ namespace Altinn.Platform.Storage.DataCleanup.Services
                         }
                         else
                         {
-                            IQueryable<Instance> instanceQuery = instancesContainer.GetItemLinqQueryable<Instance>()
+                            IQueryable<Instance> instanceQuery = instancesContainer
+                                .GetItemLinqQueryable<Instance>()
                                 .Where(i => i.Id.Equals(dataElement.InstanceGuid));
 
                             var instanceIterator = instanceQuery.ToFeedIterator();
                             var res = await instanceIterator.ReadNextAsync();
                             Instance instance = res.FirstOrDefault();
 
-                            if (instance != null)
+                            if (instance == null)
                             {
+                                dataElements.Add(dataElement);
+                            } 
+                            else
+                            { 
                                 retrievedInstances.Add(instance.Id, instance);
                                 if (instance.CompleteConfirmations.Any(c => c.StakeholderId.ToLower().Equals(instance.Org) && c.ConfirmedOn <= DateTime.UtcNow.AddDays(-7)))
                                 {

--- a/src/DataCleanup/Services/CosmosService.cs
+++ b/src/DataCleanup/Services/CosmosService.cs
@@ -251,10 +251,13 @@ namespace Altinn.Platform.Storage.DataCleanup.Services
                             var res = await instanceIterator.ReadNextAsync();
                             Instance instance = res.FirstOrDefault();
 
-                            retrievedInstances.Add(instance.Id, instance);
-                            if (instance.CompleteConfirmations.Any(c => c.StakeholderId.ToLower().Equals(instance.Org) && c.ConfirmedOn <= DateTime.UtcNow.AddDays(-7)))
+                            if (instance != null)
                             {
-                                dataElements.Add(dataElement);
+                                retrievedInstances.Add(instance.Id, instance);
+                                if (instance.CompleteConfirmations.Any(c => c.StakeholderId.ToLower().Equals(instance.Org) && c.ConfirmedOn <= DateTime.UtcNow.AddDays(-7)))
+                                {
+                                    dataElements.Add(dataElement);
+                                }
                             }
                         }
                     }

--- a/src/DataCleanup/Services/CosmosService.cs
+++ b/src/DataCleanup/Services/CosmosService.cs
@@ -254,7 +254,9 @@ namespace Altinn.Platform.Storage.DataCleanup.Services
 
                             if (instance == null)
                             {
-                                dataElements.Add(dataElement);
+                                _logger.LogError("Orphan data element found during cleanup, root cause investigation required.\n" +
+                                    "Instance Guid: {instanceGuid}, blobStoragePath: {blobStoragePath}, dataElementId: {dataElementId}", 
+                                    dataElement.InstanceGuid, dataElement.BlobStoragePath, dataElement.Id);
                             } 
                             else
                             { 


### PR DESCRIPTION
Instance may not existing when cleaning up data elements marked for hard delete.

This PR does NOT fix any underlying errors that may be the cause of instances being deleted before data elements.

## Description

## Related Issue(s)
- #85 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
