### PR TITLE
extended func timeout to 1 hr

### DIFF
--- a/src/DataCleanup/host.json
+++ b/src/DataCleanup/host.json
@@ -1,5 +1,6 @@
 {
   "version": "2.0",
+  "functionTimeout": "01:00:00",
   "logging": {
     "applicationInsights": {
       "samplingExcludedTypes": "Request",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cleanup function has timed out lately due to heavy load of testdata. 
Adjustet function timeout to 1 hour to allow the cleanup to complete deletion of data. 

## Related Issue(s)
- N/A
