### PR TITLE
Set the AllowNewCopy property for an archived instance

### DIFF
--- a/src/Storage/Authorization/ClaimsPrincipalProvider.cs
+++ b/src/Storage/Authorization/ClaimsPrincipalProvider.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Http;
+
+namespace Altinn.Platform.Storage.Authorization
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IClaimsPrincipalProvider"/> using the HttpContext to obtain
+    /// the current claims principal needed for the application to make calls to other services.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class ClaimsPrincipalProvider : IClaimsPrincipalProvider
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClaimsPrincipalProvider"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The http context accessor</param>
+        public ClaimsPrincipalProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc/>
+        public ClaimsPrincipal GetUser()
+        {
+            return _httpContextAccessor.HttpContext.User;
+        }
+    }
+}

--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -16,26 +16,25 @@ namespace Altinn.Platform.Storage.Authorization
         /// <summary>
         /// Authorize instances, and returns a list of MesseageBoxInstances with information about read and write rights of each instance.
         /// </summary>
-        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(ClaimsPrincipal user, List<Instance> instances);
+        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances);
 
         /// <summary>
         /// Authorizes a given action on an instance.
         /// </summary>
         /// <returns>true if the user is authorized.</returns>
-        public Task<bool> AuthorizeInstanceAction(ClaimsPrincipal user, Instance instance, string action, string task = null);
+        public Task<bool> AuthorizeInstanceAction(Instance instance, string action, string task = null);
 
         /// <summary>
         /// Authorize instances, and returns a list of instances that the user has the right to read.
         /// </summary>
-        public Task<List<Instance>> AuthorizeInstances(ClaimsPrincipal user, List<Instance> instances);
+        public Task<List<Instance>> AuthorizeInstances(List<Instance> instances);
 
         /// <summary>
         /// Verifies a scope claim based on claimsprincipal.
         /// </summary>
         /// <param name="requiredScope">Requiered scope.</param>
-        /// <param name="user">Claim principal from http context.</param>
         /// <returns>true if the given ClaimsPrincipal or on of its identities have contains the given scope.</returns>
-        public bool ContainsRequiredScope(List<string> requiredScope, ClaimsPrincipal user);
+        public bool UserHasRequiredScope(List<string> requiredScope);
 
         /// <summary>
         /// Sends in a request and get response with result of the request

--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -16,7 +16,7 @@ namespace Altinn.Platform.Storage.Authorization
         /// <summary>
         /// Authorize instances, and returns a list of MesseageBoxInstances with information about read and write rights of each instance.
         /// </summary>
-        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances);
+        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances, bool includeInstantiate);
 
         /// <summary>
         /// Authorizes a given action on an instance.

--- a/src/Storage/Authorization/IClaimsPrincipalProvider.cs
+++ b/src/Storage/Authorization/IClaimsPrincipalProvider.cs
@@ -1,0 +1,18 @@
+﻿using System.Security.Claims;
+
+namespace Altinn.Platform.Storage.Authorization
+{
+    /// <summary>
+    /// Defines the methods required for an implementation of a user JSON Web Token provider.
+    /// The provider is used by client implementations that needs the user token in requests 
+    /// against other systems.
+    /// </summary>
+    public interface IClaimsPrincipalProvider
+    {
+        /// <summary>
+        /// Defines a method that can return a claims principal for the current user.
+        /// </summary>
+        /// <returns>The Json Web Token for the current user.</returns>
+        public ClaimsPrincipal GetUser();
+    }
+}

--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -132,7 +132,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (orgClaim != null)
             {
-                if (!_authorizationService.ContainsRequiredScope(_generalSettings.InstanceReadScope, User))
+                if (!_authorizationService.UserHasRequiredScope(_generalSettings.InstanceReadScope))
                 {
                     return Forbid();
                 }
@@ -211,7 +211,7 @@ namespace Altinn.Platform.Storage.Controllers
                         FilterOutDeletedDataElements(instance);
                     }
 
-                    result.Instances = await _authorizationService.AuthorizeInstances(User, result.Instances);
+                    result.Instances = await _authorizationService.AuthorizeInstances(result.Instances);
                     result.Count = result.Instances.Count;
                 }
 

--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -221,8 +221,7 @@ namespace Altinn.Platform.Storage.Controllers
             }
 
             List<MessageBoxInstance> authorizedInstanceList =
-                await _authorizationService.AuthorizeMesseageBoxInstances(
-                    HttpContext.User, new List<Instance> { instance });
+                await _authorizationService.AuthorizeMesseageBoxInstances(new List<Instance> { instance });
             if (authorizedInstanceList.Count <= 0)
             {
                 return Forbid();
@@ -557,8 +556,8 @@ namespace Altinn.Platform.Storage.Controllers
                 }
             });
 
-            List<MessageBoxInstance> authorizedInstances =
-                    await _authorizationService.AuthorizeMesseageBoxInstances(HttpContext.User, allInstances);
+            List<MessageBoxInstance> authorizedInstances = 
+                await _authorizationService.AuthorizeMesseageBoxInstances(allInstances);
 
             if (!authorizedInstances.Any())
             {

--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Enums;
@@ -15,7 +14,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
 namespace Altinn.Platform.Storage.Controllers
@@ -220,8 +218,15 @@ namespace Altinn.Platform.Storage.Controllers
                 return NotFound($"Could not find instance {instanceOwnerPartyId}/{instanceGuid}");
             }
 
+            bool includeInstantiate = false;
+            if (instance.Status.IsArchived) 
+            {
+                var application = await _applicationRepository.FindOne(instance.AppId, instance.AppId.Split("/")[0]);
+                includeInstantiate = application?.CopyInstanceSettings?.Enabled == true;
+            }
+
             List<MessageBoxInstance> authorizedInstanceList =
-                await _authorizationService.AuthorizeMesseageBoxInstances(new List<Instance> { instance });
+                await _authorizationService.AuthorizeMesseageBoxInstances(new List<Instance> { instance }, includeInstantiate);
             if (authorizedInstanceList.Count <= 0)
             {
                 return Forbid();
@@ -557,7 +562,7 @@ namespace Altinn.Platform.Storage.Controllers
             });
 
             List<MessageBoxInstance> authorizedInstances = 
-                await _authorizationService.AuthorizeMesseageBoxInstances(allInstances);
+                await _authorizationService.AuthorizeMesseageBoxInstances(allInstances, false);
 
             if (!authorizedInstances.Any())
             {

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -102,7 +102,7 @@ namespace Altinn.Platform.Storage.Controllers
                     break;
             }
 
-            bool authorized = await _authorizationService.AuthorizeInstanceAction(HttpContext.User, existingInstance, action, taskId);
+            bool authorized = await _authorizationService.AuthorizeInstanceAction(existingInstance, action, taskId);
 
             if (!authorized)
             {
@@ -134,7 +134,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// </summary>
         /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
         /// <param name="instanceGuid">The id of the instance whos process history to retrieve.</param>
-        /// <returns>Returns a list of the process events.</returns>        
+        /// <returns>Returns a list of the process events.</returns>
         [HttpGet("history")]
         [Authorize(Policy = "InstanceRead")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+
 using Altinn.Common.AccessToken;
 using Altinn.Common.AccessToken.Configuration;
 using Altinn.Common.AccessToken.Services;
@@ -10,6 +11,7 @@ using Altinn.Common.PEP.Clients;
 using Altinn.Common.PEP.Configuration;
 using Altinn.Common.PEP.Implementation;
 using Altinn.Common.PEP.Interfaces;
+
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Clients;
 using Altinn.Platform.Storage.Configuration;
@@ -234,13 +236,14 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
     });
 
-    services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+    services.AddHttpContextAccessor();
+    services.AddSingleton<IClaimsPrincipalProvider, ClaimsPrincipalProvider>();
 
     // hookup Cosmos DB
     AzureCosmosSettings cosmosSettings = config.GetSection("AzureCosmosSettings").Get<AzureCosmosSettings>();
     CosmosClientOptions options = new()
     {
-        ConnectionMode = ConnectionMode.Direct,        
+        ConnectionMode = ConnectionMode.Direct,
         GatewayModeMaxConnectionLimit = 100
     };
     CosmosClient cosmosClient = new(cosmosSettings.EndpointUri, cosmosSettings.PrimaryKey, options);

--- a/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -137,6 +137,29 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Assert.Equal(HttpStatusCode.Forbidden, responseMessage.StatusCode);
         }
 
+        [Fact]
+        public async void GetMessageBoxInstance_ArchivedInstanceCanBeCopied_UserHaveRights_InstanceIsSuccessfullyMappedAndReturned()
+        {
+            // Arrange
+            string instanceId = "1337/07274f48-8313-4e2d-9788-bbdacef5a54e";
+
+            HttpClient client = GetTestClient();
+            client.DefaultRequestHeaders.Authorization = 
+                new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+            // Act
+            HttpResponseMessage responseMessage = 
+                await client.GetAsync($"{BasePath}/sbl/instances/{instanceId}?language=en");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+
+            string responseContent = await responseMessage.Content.ReadAsStringAsync();
+            MessageBoxInstance actual = JsonConvert.DeserializeObject<MessageBoxInstance>(responseContent);
+
+            Assert.True(actual.AllowNewCopy);
+        }
+
         /// <summary>
         /// Scenario:
         ///   Restore a soft deleted instance in storage.

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -172,7 +172,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
 
             // Act
-            List<MessageBoxInstance> actual = await _authzService.AuthorizeMesseageBoxInstances(instances);
+            List<MessageBoxInstance> actual = await _authzService.AuthorizeMesseageBoxInstances(instances, false);
 
             // Assert
             Assert.Equal(expected, actual);

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -34,12 +34,14 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         private readonly IPDP _pdpMockSI;
         private readonly Mock<IPDP> _pdpSimpleMock;
         private readonly Mock<IInstanceRepository> _instanceRepository = new Mock<IInstanceRepository>();
+        private readonly Mock<IClaimsPrincipalProvider> _claimsPrincipalProviderMock = new Mock<IClaimsPrincipalProvider>();
 
         public AuthorizationServiceTest()
         {
             _pdpSimpleMock = new Mock<IPDP>();
             _pdpMockSI = new PepWithPDPAuthorizationMockSI(_instanceRepository.Object);
-            _authzService = new AuthorizationService(_pdpMockSI, Mock.Of<ILogger<IAuthorization>>());
+            _authzService = new AuthorizationService(
+                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<IAuthorization>>());
         }
 
         [Fact]
@@ -59,15 +61,17 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             _pdpSimpleMock.Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
                 .ReturnsAsync(res);
 
-            var sut = new AuthorizationService(_pdpSimpleMock.Object, Mock.Of<ILogger<IAuthorization>>());
+            var sut = new AuthorizationService(
+                _pdpSimpleMock.Object, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<IAuthorization>>());
             await sut.GetDecisionForRequest(new XacmlJsonRequestRoot());
 
             _pdpSimpleMock.Verify(m => m.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Once());
         }
 
         [Fact]
-        public void ContainsRequiredScope_CaseIgnored_ReturnsTrue()
+        public void UserHasRequiredScope_CaseIgnored_ReturnsTrue()
         {
+            // Arrange
             string reqiured = "altinn:serviceowner/instances.read";
 
             var claims = new List<Claim>();
@@ -76,15 +80,19 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var identity = new ClaimsIdentity("AuthenticationTypes.Federation");
             identity.AddClaims(claims);
             var principal = new ClaimsPrincipal(identity);
+            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(principal);
+            
+            // Act
+            var actual = _authzService.UserHasRequiredScope(new List<string> { reqiured });
 
-            var actual = _authzService.ContainsRequiredScope(new List<string> { reqiured }, principal);
-
+            // Assert
             Assert.True(actual);
         }
 
         [Fact]
-        public void ContainsRequiredScope_MissingRequiredScope_ReturnsFalse()
+        public void UserHasRequiredScope_MissingRequiredScope_ReturnsFalse()
         {
+            // Arrange
             string reqiured = "altinn:serviceowner/instances.read";
 
             var claims = new List<Claim>();
@@ -99,8 +107,12 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             identity.AddClaims(claims);
             var principal = new ClaimsPrincipal(identity);
 
-            var actual = _authzService.ContainsRequiredScope(new List<string> { reqiured }, principal);
+            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(principal);
 
+            // Act
+            var actual = _authzService.UserHasRequiredScope(new List<string> { reqiured });
+
+            // Assert
             Assert.False(actual);
         }
 
@@ -157,9 +169,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             List<MessageBoxInstance> expected = new List<MessageBoxInstance>();
             List<Instance> instances = new List<Instance>();
+            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
 
             // Act
-            List<MessageBoxInstance> actual = await _authzService.AuthorizeMesseageBoxInstances(CreateUserClaims(3), instances);
+            List<MessageBoxInstance> actual = await _authzService.AuthorizeMesseageBoxInstances(instances);
 
             // Assert
             Assert.Equal(expected, actual);

--- a/test/UnitTest/data/apps/tdd/endring-av-navn/config/applicationmetadata.json
+++ b/test/UnitTest/data/apps/tdd/endring-av-navn/config/applicationmetadata.json
@@ -10,6 +10,9 @@
     "nb-NO": "Endring av navn (RF-1453)",
     "en": "Name change"
   },
+  "copyInstanceSettings": {
+    "enabled": true
+  },
   "dataTypes": [
     {
       "id": "default",
@@ -25,10 +28,6 @@
       "id": "default_with_fileScan",
       "allowedContentTypes": [ "application/xml" ],
       "maxCount": 1,
-      "appLogic": {
-        "autoCreate": true,
-        "ClassRef": "App.IntegrationTests.Mocks.Apps.tdd.endring_av_navn.Skjema"
-      },
       "taskId": "Task_1",
       "enableFileScan": true
     }

--- a/test/UnitTest/data/cosmoscollections/instances/1337/07274f48-8313-4e2d-9788-bbdacef5a54e.json
+++ b/test/UnitTest/data/cosmoscollections/instances/1337/07274f48-8313-4e2d-9788-bbdacef5a54e.json
@@ -1,0 +1,32 @@
+{
+  "id": "07274f48-8313-4e2d-9788-bbdacef5a54e",
+  "instanceOwner": {
+    "partyId": "1337",
+    "organisationNumber": "725736800"
+  },
+  "appId": "tdd/endring-av-navn",
+  "org": "tdd",
+  "visibleAfter": "2021-03-07T05:16:23.6793863Z",
+  "process": {
+    "started": "2021-04-07T05:16:23.6793863Z",
+    "startEvent": "StartEvent_1",
+    "ended": "2021-04-07T05:16:47.7911165Z",
+    "endEvent": "EndEvent_1"
+  },
+  "status": {
+    "isArchived": true,
+    "archived": "2021-04-07T05:16:47.7911165Z",
+    "isSoftDeleted": true,
+    "softDeleted": "2021-04-08T05:18:18.9095109Z",
+    "isHardDeleted": true,
+    "hardDeleted": "2021-04-08T05:18:54.6821209Z",
+    "readStatus": "Read"
+  },
+  "appOwner": {},
+  "data": [
+  ],
+  "created": "2021-04-07T05:16:23.6793863Z",
+  "createdBy": "1337",
+  "lastChanged": "2021-04-07T05:16:47.7911165Z",
+  "lastChangedBy": "1337"
+}

--- a/test/UnitTest/data/cosmoscollections/instances/1337/07274f48-8313-4e2d-9788-bbdacef5a54e.json
+++ b/test/UnitTest/data/cosmoscollections/instances/1337/07274f48-8313-4e2d-9788-bbdacef5a54e.json
@@ -6,7 +6,7 @@
   },
   "appId": "tdd/endring-av-navn",
   "org": "tdd",
-  "visibleAfter": "2021-03-07T05:16:23.6793863Z",
+  "visibleAfter": "2021-04-06T05:16:23.6793863Z",
   "process": {
     "started": "2021-04-07T05:16:23.6793863Z",
     "startEvent": "StartEvent_1",
@@ -16,10 +16,8 @@
   "status": {
     "isArchived": true,
     "archived": "2021-04-07T05:16:47.7911165Z",
-    "isSoftDeleted": true,
-    "softDeleted": "2021-04-08T05:18:18.9095109Z",
-    "isHardDeleted": true,
-    "hardDeleted": "2021-04-08T05:18:54.6821209Z",
+    "isSoftDeleted": false,
+    "isHardDeleted": false,
     "readStatus": "Read"
   },
   "appOwner": {},


### PR DESCRIPTION
## Description
Set the AllowNewCopy property for an archived instance. AllowNewCopy is the be set for archived instances for apps where the copy feature is enabled and the user have the necessary rights.

## Related Issue(s)
- https://github.com/Altinn/altinn-platform/issues/355

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
