### PR TITLE
added direct reference to webjobs package

### DIFF
--- a/src/CosmosBackup/Altinn.Platform.Storage.CosmosBackup.csproj
+++ b/src/CosmosBackup/Altinn.Platform.Storage.CosmosBackup.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.15.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.36" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added direct reference to Microsoft.Azure.Webjobs
error message `Microsoft.Azure.WebJobs.Extensions.Storage.Blobs: Could not load type 'Microsoft.Azure.WebJobs.ParameterBindingData' from assembly 'Microsoft.Azure.WebJobs, Version=3.0.34.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.` cannot find v 3.0.34 in nuget.org
