### PR TITLE
return bad request if empty blob persisted

### DIFF
--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -288,6 +288,13 @@ namespace Altinn.Platform.Storage.Controllers
 
             newData.Filename = HttpUtility.UrlDecode(newData.Filename);
             (long length, DateTimeOffset blobTimestamp) = await _dataRepository.WriteDataToStorage(instance.Org, theStream, newData.BlobStoragePath);
+
+            if (length == 0)
+            {
+                await _dataRepository.DeleteDataInStorage(instance.Org, newData.BlobStoragePath);
+                return BadRequest("Empty stream provided. Cannot persist data.");
+            }
+
             newData.Size = length;
 
             if (User.GetOrg() == instance.Org)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
There is a number of empty blbs in blob storage. As the metadatasays the size of the dataelement is 0, we should be able to reject these uploads and remove them from blob storage and indicate to the caller that an error occured.

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green

