### PR TITLE
feat(TextResource): add defaultValue to TextResourceVariable

### DIFF
--- a/src/Storage.Interface/Models/TextResource.cs
+++ b/src/Storage.Interface/Models/TextResource.cs
@@ -74,5 +74,11 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "dataSource")]
         public string DataSource { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the defaultValue
+        /// </summary>
+        [JsonProperty(PropertyName = "defaultValue")]
+        public string DefaultValue { get; set; }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds support for a defaultValue option in variables in text resources. This would allow for app developers to provide a value to print if the variable points to a null-value in the datamodel. The current behavior is that the app displays the path to the datamodel.

## Related Issue(s)
- Altinn/app-frontend-react#1440
- Altinn/app-frontend-react#754

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable) https://github.com/Altinn/altinn-studio-docs/pull/1134
