### PR TITLE
Reduced fetch of data elements after change to maintain readstatus/lastchanged* when changing data elements

### DIFF
--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -90,7 +90,7 @@ namespace Altinn.Platform.Storage.Controllers
             Stopwatch stopwatch = Stopwatch.StartNew();
             do
             {
-                instancesResponse = await instanceRepository.GetInstancesFromQuery(options, instancesResponse.ContinuationToken, 5000);
+                instancesResponse = await instanceRepository.GetInstancesFromQuery(options, instancesResponse.ContinuationToken, 5000, true);
                 successfullyDeleted += await CleanupInstancesInternal(instancesResponse.Instances, []);
                 processed += (int)instancesResponse.Count;
             }

--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -203,7 +203,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             try
             {
-                InstanceQueryResponse result = await _instanceRepository.GetInstancesFromQuery(queryParams, continuationToken, pageSize);
+                InstanceQueryResponse result = await _instanceRepository.GetInstancesFromQuery(queryParams, continuationToken, pageSize, true);
 
                 if (!string.IsNullOrEmpty(result.Exception))
                 {

--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -537,14 +537,19 @@ namespace Altinn.Platform.Storage.Controllers
             Instance updatedInstance;
             try
             {
+                ReadStatus? oldStatus = null;
                 if (instance.Status == null)
                 {
                     instance.Status = new InstanceStatus();
                 }
+                else
+                {
+                    oldStatus = instance.Status.ReadStatus;
+                }
 
                 instance.Status.ReadStatus = newStatus;
 
-                updatedInstance = await _instanceRepository.Update(instance);
+                updatedInstance = (oldStatus == null || oldStatus != newStatus) ? await _instanceRepository.Update(instance) : instance;
                 updatedInstance.SetPlatformSelfLinks(_storageBaseAndHost);
             }
             catch (Exception e)

--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -130,7 +130,7 @@ namespace Altinn.Platform.Storage.Controllers
                 languageId = language;
             }
 
-            (Instance instance, _) = await _instanceRepository.GetOne(instanceGuid, true);
+            (Instance instance, _) = await _instanceRepository.GetOne(instanceGuid, false);
 
             if (instance == null)
             {

--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -96,7 +96,7 @@ namespace Altinn.Platform.Storage.Controllers
                 queryParams.Remove("searchString");
             }
 
-            InstanceQueryResponse queryResponse = await _instanceRepository.GetInstancesFromQuery(queryParams, null, 100);
+            InstanceQueryResponse queryResponse = await _instanceRepository.GetInstancesFromQuery(queryParams, null, 100, false);
 
             AddQueryModelToTelemetry(queryModel);
 

--- a/src/Storage/Helpers/InstanceHelper.cs
+++ b/src/Storage/Helpers/InstanceHelper.cs
@@ -98,6 +98,7 @@ namespace Altinn.Platform.Storage.Helpers
         {
             if (instance.Process != null)
             {
+                string taskType;
                 if (instance.Process.Ended != null && instance.Status?.Archived == null)
                 {
                     return "Submit";
@@ -106,17 +107,17 @@ namespace Altinn.Platform.Storage.Helpers
                 {
                     return "Archived";
                 }
-                else if (instance.Process?.CurrentTask?.AltinnTaskType != null)
+                else if ((taskType = instance.Process?.CurrentTask?.AltinnTaskType) != null)
                 {
-                    if (instance.Process.CurrentTask.AltinnTaskType.Equals("confirmation", StringComparison.OrdinalIgnoreCase))
+                    if (taskType.Equals("confirmation", StringComparison.OrdinalIgnoreCase))
                     {
                         return "Confirmation";
                     }
-                    else if (instance.Process.CurrentTask.AltinnTaskType.Equals("feedback", StringComparison.OrdinalIgnoreCase))
+                    else if (taskType.Equals("feedback", StringComparison.OrdinalIgnoreCase))
                     {
                         return "Feedback";
                     }
-                    else if (instance.Process.CurrentTask.AltinnTaskType.Equals("signing", StringComparison.OrdinalIgnoreCase))
+                    else if (taskType.Equals("signing", StringComparison.OrdinalIgnoreCase))
                     {
                         return "Signing";
                     }

--- a/src/Storage/Helpers/InstanceHelper.cs
+++ b/src/Storage/Helpers/InstanceHelper.cs
@@ -24,7 +24,7 @@ namespace Altinn.Platform.Storage.Helpers
 
             DateTime createdDateTime = visibleAfter != null && visibleAfter > instance.Created ? (DateTime)visibleAfter : instance.Created.Value;
 
-            MessageBoxInstance messageBoxInstance = new MessageBoxInstance
+            MessageBoxInstance messageBoxInstance = new()
             {
                 CreatedDateTime = createdDateTime,
                 DueDateTime = instance.DueBefore,
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Helpers
         /// <param name="instanceEvents">List of instance events to convert.</param>
         public static List<SblInstanceEvent> ConvertToSBLInstanceEvent(List<InstanceEvent> instanceEvents)
         {
-            List<SblInstanceEvent> simpleEvents = new List<SblInstanceEvent>();
+            List<SblInstanceEvent> simpleEvents = [];
             foreach (InstanceEvent instanceEvent in instanceEvents)
             {
                 simpleEvents.Add(
@@ -210,7 +210,7 @@ namespace Altinn.Platform.Storage.Helpers
         /// <param name="instances">The list of applications to process.</param>
         public static void RemoveHiddenInstances(Dictionary<string, Application> applications, List<Instance> instances)
         {
-            List<Instance> instancesToRemove = new List<Instance>();
+            List<Instance> instancesToRemove = [];
 
             foreach (Instance instance in instances)
             {

--- a/src/Storage/Helpers/InstanceHelper.cs
+++ b/src/Storage/Helpers/InstanceHelper.cs
@@ -106,22 +106,23 @@ namespace Altinn.Platform.Storage.Helpers
                 {
                     return "Archived";
                 }
-                else if (instance.Process.CurrentTask.AltinnTaskType.Equals("confirmation", StringComparison.OrdinalIgnoreCase))
+                else if (instance.Process?.CurrentTask?.AltinnTaskType != null)
                 {
-                    return "Confirmation";
+                    if (instance.Process.CurrentTask.AltinnTaskType.Equals("confirmation", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return "Confirmation";
+                    }
+                    else if (instance.Process.CurrentTask.AltinnTaskType.Equals("feedback", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return "Feedback";
+                    }
+                    else if (instance.Process.CurrentTask.AltinnTaskType.Equals("signing", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return "Signing";
+                    }
                 }
-                else if (instance.Process.CurrentTask.AltinnTaskType.Equals("feedback", StringComparison.OrdinalIgnoreCase))
-                {
-                    return "Feedback";
-                }
-                else if (instance.Process.CurrentTask.AltinnTaskType.Equals("signing", StringComparison.OrdinalIgnoreCase))
-                {
-                    return "Signing";
-                }
-                else
-                {
-                    return "FormFilling";
-                }
+
+                return "FormFilling";
             }
             else
             {

--- a/src/Storage/Migration/v0.03/01-setup-functions.sql
+++ b/src/Storage/Migration/v0.03/01-setup-functions.sql
@@ -1,0 +1,117 @@
+-- instances ---------------------------------------------------
+CREATE OR REPLACE FUNCTION storage.readinstancefromquery_v2(
+    _appId TEXT DEFAULT NULL,
+    _appIds TEXT[] DEFAULT NULL,
+    _archiveReference TEXT DEFAULT NULL,
+    _continue_idx BIGINT DEFAULT 0,
+    _created_eq TIMESTAMPTZ DEFAULT NULL,
+    _created_gt TIMESTAMPTZ DEFAULT NULL,
+    _created_gte TIMESTAMPTZ DEFAULT NULL,
+    _created_lt TIMESTAMPTZ DEFAULT NULL,
+    _created_lte TIMESTAMPTZ DEFAULT NULL,
+    _dueBefore_eq TEXT DEFAULT NULL,
+    _dueBefore_gt TEXT DEFAULT NULL,
+    _dueBefore_gte TEXT DEFAULT NULL,
+    _dueBefore_lt TEXT DEFAULT NULL,
+    _dueBefore_lte TEXT DEFAULT NULL,
+    _excludeConfirmedBy JSONB[] DEFAULT NULL,
+    _includeElements BOOL DEFAULT TRUE,
+    _instanceOwner_partyId INTEGER DEFAULT NULL,
+    _instanceOwner_partyIds INTEGER[] DEFAULT NULL,
+    _lastChanged_eq TIMESTAMPTZ DEFAULT NULL,
+    _lastChanged_gt TIMESTAMPTZ DEFAULT NULL,
+    _lastChanged_gte TIMESTAMPTZ DEFAULT NULL,
+    _lastChanged_idx TIMESTAMPTZ DEFAULT NULL,
+    _lastChanged_lt TIMESTAMPTZ DEFAULT NULL,
+    _lastChanged_lte TIMESTAMPTZ DEFAULT NULL,
+    _org TEXT DEFAULT NULL,
+    _process_currentTask TEXT DEFAULT NULL,
+    _process_ended_eq TEXT DEFAULT NULL,
+    _process_ended_gt TEXT DEFAULT NULL,
+    _process_ended_gte TEXT DEFAULT NULL,
+    _process_ended_lt TEXT DEFAULT NULL,
+    _process_ended_lte TEXT DEFAULT NULL,
+    _process_isComplete BOOLEAN DEFAULT NULL,
+    _size INTEGER DEFAULT 100,
+    _sort_ascending BOOLEAN DEFAULT FALSE,
+    _status_isActiveOrSoftDeleted BOOLEAN  DEFAULT NULL,
+    _status_isArchived BOOLEAN DEFAULT NULL,
+    _status_isArchivedOrSoftDeleted BOOLEAN DEFAULT NULL,
+    _status_isHardDeleted BOOLEAN DEFAULT NULL,
+    _status_isSoftDeleted BOOLEAN DEFAULT NULL,
+    _visibleAfter_eq TEXT DEFAULT NULL,
+    _visibleAfter_gt TEXT DEFAULT NULL,
+    _visibleAfter_gte TEXT DEFAULT NULL,
+    _visibleAfter_lt TEXT DEFAULT NULL,
+    _visibleAfter_lte TEXT DEFAULT NULL
+    )
+    RETURNS TABLE (id BIGINT, instance JSONB, element JSONB)
+    LANGUAGE 'plpgsql'
+    
+AS $BODY$
+BEGIN
+    IF _sort_ascending IS NULL THEN
+        _sort_ascending := false;
+    END IF;
+
+    RETURN QUERY
+    WITH filteredInstances AS
+    (
+        SELECT i.id, i.instance, i.lastchanged FROM storage.instances i
+        WHERE 1 = 1
+            AND (_continue_idx <= 0 OR
+                (_continue_idx > 0 AND _sort_ascending = true  AND (i.lastchanged > _lastChanged_idx OR (i.lastchanged = _lastChanged_idx AND i.id > _continue_idx))) OR
+                (_continue_idx > 0 AND _sort_ascending = false AND (i.lastchanged < _lastChanged_idx OR (i.lastchanged = _lastChanged_idx AND i.id < _continue_idx))))
+            AND (_appId IS NULL OR i.appid = _appId)
+            AND (_appIds IS NULL OR i.appid = ANY(_appIds))
+            AND (_archiveReference IS NULL OR i.instance ->> 'Id' like '%' || _archiveReference)		
+            AND (_created_gte IS NULL OR i.created >= _created_gte)
+            AND (_created_gt  IS NULL OR i.created >  _created_gt)
+            AND (_created_lte IS NULL OR i.created <= _created_lte)
+            AND (_created_lt  IS NULL OR i.created <  _created_lt)
+            AND (_created_eq  IS NULL OR i.created =  _created_eq)
+            AND (_dueBefore_gte IS NULL OR i.instance ->> 'DueBefore' >= _dueBefore_gte)
+            AND (_dueBefore_gt  IS NULL OR i.instance ->> 'DueBefore' >  _dueBefore_gt)
+            AND (_dueBefore_lte IS NULL OR i.instance ->> 'DueBefore' <= _dueBefore_lte)
+            AND (_dueBefore_lt  IS NULL OR i.instance ->> 'DueBefore' <  _dueBefore_lt)
+            AND (_dueBefore_eq   IS NULL OR i.instance ->> 'DueBefore' =  _dueBefore_eq)
+            AND (_excludeConfirmedBy IS NULL OR i.instance -> 'CompleteConfirmations' IS NULL OR NOT i.instance -> 'CompleteConfirmations' @> ANY (_excludeConfirmedBy))
+            AND (_instanceOwner_partyId IS NULL OR partyId = _instanceOwner_partyId)
+            AND (_instanceOwner_partyIds IS NULL OR partyId = ANY(_instanceOwner_partyIds))
+            AND (_lastChanged_gte IS NULL OR i.lastchanged >= _lastChanged_gte)
+            AND (_lastChanged_gt  IS NULL OR i.lastchanged >  _lastChanged_gt)
+            AND (_lastChanged_lte IS NULL OR i.lastchanged <= _lastChanged_lte)
+            AND (_lastChanged_lt  IS NULL OR i.lastchanged <  _lastChanged_lt)
+            AND (_lastChanged_eq  IS NULL OR i.lastchanged =  _lastChanged_eq)
+            AND (_org IS NULL OR i.org = _org)
+            AND (_process_currentTask IS NULL OR i.instance -> 'Process' -> 'CurrentTask' ->> 'ElementId' = _process_currentTask)
+            AND (_process_ended_gte IS NULL OR i.instance -> 'Process' ->> 'Ended' >= _process_ended_gte)
+            AND (_process_ended_gt  IS NULL OR i.instance -> 'Process' ->> 'Ended' >  _process_ended_gt)
+            AND (_process_ended_lte IS NULL OR i.instance -> 'Process' ->> 'Ended' <= _process_ended_lte)
+            AND (_process_ended_lt  IS NULL OR i.instance -> 'Process' ->> 'Ended' <  _process_ended_lt)
+            AND (_process_ended_eq  IS NULL OR i.instance -> 'Process' ->> 'Ended' =  _process_ended_eq)
+            AND (_process_isComplete IS NULL OR (_process_isComplete = TRUE AND i.instance -> 'Process' -> 'Ended' IS NOT NULL) OR (_process_isComplete = FALSE AND i.instance -> 'Process' -> 'CurrentTask' IS NOT NULL))
+            AND ((_status_isActiveOrSoftDeleted IS NULL OR _status_isActiveOrSoftDeleted = false) OR ((i.instance -> 'Status' -> 'IsArchived')::boolean = false OR (i.instance -> 'Status' -> 'IsSoftDeleted')::boolean = true))           
+            AND (_status_isArchived IS NULL OR  (i.instance -> 'Status' -> 'IsArchived')::boolean = _status_isArchived)
+            AND ((_status_isArchivedOrSoftDeleted IS NULL OR _status_isArchivedOrSoftDeleted = false) OR ((i.instance -> 'Status' -> 'IsArchived')::boolean = true OR (i.instance -> 'Status' -> 'IsSoftDeleted')::boolean = true))                
+            AND (_status_isHardDeleted IS NULL OR  (i.instance -> 'Status' -> 'IsHardDeleted')::boolean = _status_isHardDeleted)
+            AND (_status_isSoftDeleted IS NULL OR  (i.instance -> 'Status' -> 'IsSoftDeleted')::boolean = _status_isSoftDeleted)                     
+            AND (_visibleAfter_gte IS NULL OR i.instance ->> 'VisibleAfter' >= _visibleAfter_gte)
+            AND (_visibleAfter_gt  IS NULL OR i.instance ->> 'VisibleAfter' >  _visibleAfter_gt)
+            AND (_visibleAfter_lte IS NULL OR i.instance ->> 'VisibleAfter' <= _visibleAfter_lte)
+            AND (_visibleAfter_lt  IS NULL OR i.instance ->> 'VisibleAfter' <  _visibleAfter_lt)
+            AND (_visibleAfter_eq  IS NULL OR i.instance ->> 'VisibleAfter' =  _visibleAfter_eq)
+        ORDER BY
+            (CASE WHEN _sort_ascending = true  THEN i.lastChanged END) ASC,
+            (CASE WHEN _sort_ascending = false THEN i.lastChanged END) DESC,
+            i.id
+        FETCH FIRST _size ROWS ONLY
+    )
+        SELECT filteredInstances.id, filteredInstances.instance, d.element FROM filteredInstances
+            LEFT JOIN storage.dataelements d ON filteredInstances.id = d.instanceInternalId AND _includeElements = TRUE
+        ORDER BY
+            (CASE WHEN _sort_ascending = true  THEN filteredInstances.lastChanged END) ASC,
+            (CASE WHEN _sort_ascending = false THEN filteredInstances.lastChanged END) DESC,
+            filteredInstances.id;
+END;
+$BODY$;

--- a/src/Storage/Repository/IInstanceRepository.cs
+++ b/src/Storage/Repository/IInstanceRepository.cs
@@ -17,8 +17,9 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="queryParams">the query params</param>
         /// <param name="continuationToken">a token to get the next page, more performant than using page</param>
         /// <param name="size">The number of items per page</param>
+        /// <param name="includeDataelements">Whether to include data elements</param>
         /// <returns>The query response including the list of instances</returns>
-        Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size);
+        Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size, bool includeDataelements);
 
         /// <summary>
         /// Get an instance for a given instance id

--- a/src/Storage/Repository/IInstanceRepository.cs
+++ b/src/Storage/Repository/IInstanceRepository.cs
@@ -27,7 +27,7 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="instanceGuid">the instance guid</param>
         /// <param name="includeElements">whether to include data elements</param>
         /// <returns>The instance for the given parameters</returns>
-        Task<(Instance Instance, long InternalId)> GetOne(Guid instanceGuid, bool includeElements = true);
+        Task<(Instance Instance, long InternalId)> GetOne(Guid instanceGuid, bool includeElements);
 
         /// <summary>
         /// insert new instance into collection

--- a/src/Storage/Repository/PgDataRepository.cs
+++ b/src/Storage/Repository/PgDataRepository.cs
@@ -17,7 +17,16 @@ namespace Altinn.Platform.Storage.Repository
     /// <summary>
     /// Represents an implementation of <see cref="IDataRepository"/>.
     /// </summary>
-    public class PgDataRepository : IDataRepository
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="PgDataRepository"/> class.
+    /// </remarks>
+    /// <param name="logger">The logger to use when writing to logs.</param>
+    /// <param name="dataSource">The npgsql data source.</param>
+    /// <param name="telemetryClient">Telemetry client</param>
+    public class PgDataRepository(
+        ILogger<PgDataRepository> logger,
+        NpgsqlDataSource dataSource,
+        TelemetryClient telemetryClient = null) : IDataRepository
     {
         private readonly string _insertSql = "call storage.insertdataelement ($1, $2, $3, $4)";
         private readonly string _readSql = "select * from storage.readdataelement($1)";
@@ -25,25 +34,9 @@ namespace Altinn.Platform.Storage.Repository
         private readonly string _deleteForInstanceSql = "select * from storage.deletedataelements ($1)";
         private readonly string _updateSql = "select * from storage.updatedataelement_v2 ($1, $2, $3, $4, $5, $6)";
 
-        private readonly ILogger<PgDataRepository> _logger;
-        private readonly NpgsqlDataSource _dataSource;
-        private readonly TelemetryClient _telemetryClient;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PgDataRepository"/> class.
-        /// </summary>
-        /// <param name="logger">The logger to use when writing to logs.</param>
-        /// <param name="dataSource">The npgsql data source.</param>
-        /// <param name="telemetryClient">Telemetry client</param>
-        public PgDataRepository(
-            ILogger<PgDataRepository> logger,
-            NpgsqlDataSource dataSource,
-            TelemetryClient telemetryClient = null)
-        {
-            _logger = logger;
-            _dataSource = dataSource;
-            _telemetryClient = telemetryClient;
-        }
+        private readonly ILogger<PgDataRepository> _logger = logger;
+        private readonly NpgsqlDataSource _dataSource = dataSource;
+        private readonly TelemetryClient _telemetryClient = telemetryClient;
 
         /// <inheritdoc/>
         public async Task<DataElement> Create(DataElement dataElement, long instanceInternalId = 0)
@@ -122,8 +115,8 @@ namespace Altinn.Platform.Storage.Repository
                 throw new ArgumentOutOfRangeException(nameof(propertylist), "PropertyList can contain at most 12 entries.");
             }
 
-            List<string> elementProperties = new();
-            List<string> instanceProperties = new();
+            List<string> elementProperties = [];
+            List<string> instanceProperties = [];
             DataElement element = new();
             Instance lastChangedWrapper = new();
             bool isReadChangedToFalse = false;

--- a/src/Storage/Repository/PgInstanceEventRepository.cs
+++ b/src/Storage/Repository/PgInstanceEventRepository.cs
@@ -18,28 +18,22 @@ namespace Altinn.Platform.Storage.Repository
     /// <summary>
     /// Represents an implementation of <see cref="IInstanceEventRepository"/>.
     /// </summary>
-    public class PgInstanceEventRepository: IInstanceEventRepository
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="PgInstanceEventRepository"/> class.
+    /// </remarks>
+    /// <param name="dataSource">The npgsql data source.</param>
+    /// <param name="telemetryClient">Telemetry client</param>
+    public class PgInstanceEventRepository(
+        NpgsqlDataSource dataSource,
+        TelemetryClient telemetryClient = null) : IInstanceEventRepository
     {
         private readonly string _readSql = "select * from storage.readinstanceevent($1)";
         private readonly string _deleteSql = "select * from storage.deleteInstanceevent($1)";
         private readonly string _insertSql = "call storage.insertInstanceevent($1, $2, $3)";
         private readonly string _filterSql = "select * from storage.filterinstanceevent($1, $2, $3, $4)";
 
-        private readonly NpgsqlDataSource _dataSource;
-        private readonly TelemetryClient _telemetryClient;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PgInstanceEventRepository"/> class.
-        /// </summary>
-        /// <param name="dataSource">The npgsql data source.</param>
-        /// <param name="telemetryClient">Telemetry client</param>
-        public PgInstanceEventRepository(
-            NpgsqlDataSource dataSource,
-            TelemetryClient telemetryClient = null)
-        {
-            _dataSource = dataSource;
-            _telemetryClient = telemetryClient;
-        }
+        private readonly NpgsqlDataSource _dataSource = dataSource;
+        private readonly TelemetryClient _telemetryClient = telemetryClient;
 
         /// <inheritdoc/>
         public async Task<InstanceEvent> InsertInstanceEvent(InstanceEvent instanceEvent)

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -20,11 +20,12 @@ namespace Altinn.Platform.Storage.Repository
     /// </summary>
     public class PgInstanceRepository: IInstanceRepository
     {
+        private const string _readSqlFilteredInitial = "select * from storage.readinstancefromquery_v2 (";
         private readonly string _deleteSql = "select * from storage.deleteinstance ($1)";
         private readonly string _insertSql = "call storage.insertinstance ($1, $2, $3, $4, $5, $6, $7, $8)";
         private readonly string _upsertSql = "call storage.upsertinstance ($1, $2, $3, $4, $5, $6, $7, $8)";
         private readonly string _readSql = "select * from storage.readinstance ($1)";
-        private readonly string _readSqlFiltered = "select * from storage.readinstancefromquery (";
+        private readonly string _readSqlFiltered = _readSqlFilteredInitial;
         private readonly string _readDeletedSql = "select * from storage.readdeletedinstances ()";
         private readonly string _readDeletedElementsSql = "select * from storage.readdeletedelements ()";
         private readonly string _readSqlNoElements = "select * from storage.readinstancenoelements ($1)";
@@ -81,11 +82,12 @@ namespace Altinn.Platform.Storage.Repository
         public async Task<InstanceQueryResponse> GetInstancesFromQuery(
             Dictionary<string, StringValues> queryParams,
             string continuationToken,
-            int size)
+            int size,
+            bool includeDataelements)
         {
             try
             {
-                return await GetInstancesInternal(queryParams, continuationToken, size);
+                return await GetInstancesInternal(queryParams, continuationToken, size, includeDataelements);
             }
             catch (Exception e)
             {
@@ -161,7 +163,7 @@ namespace Altinn.Platform.Storage.Repository
 
         private static string FormatManualFunctionCall(Dictionary<string, object> postgresParams)
         {
-            StringBuilder command = new("select * from storage.readinstancefromquery (");
+            StringBuilder command = new(_readSqlFilteredInitial);
             foreach (string name in _paramTypes.Keys)
             {
                 command.Append($"{name} => ");
@@ -227,7 +229,8 @@ namespace Altinn.Platform.Storage.Repository
         private async Task<InstanceQueryResponse> GetInstancesInternal(
             Dictionary<string, StringValues> queryParams,
             string continuationToken,
-            int size)
+            int size,
+            bool includeDataelements)
         {
             DateTime lastChanged = DateTime.MinValue;
             InstanceQueryResponse queryResponse = new() { Count = 0, Instances = [] };
@@ -241,6 +244,7 @@ namespace Altinn.Platform.Storage.Repository
             postgresParams.Add("_continue_idx", continueIdx);
             postgresParams.Add("_lastChanged_idx", lastChangeIdx);
             postgresParams.Add("_size", size);
+            postgresParams.Add("_includeElements", includeDataelements);
             foreach (string name in _paramTypes.Keys)
             {
                 pgcom.Parameters.AddWithValue(_paramTypes[name], postgresParams.TryGetValue(name, out object value) ? value : DBNull.Value);
@@ -543,6 +547,7 @@ namespace Altinn.Platform.Storage.Repository
             { "_dueBefore_lt", NpgsqlDbType.Text },
             { "_dueBefore_lte", NpgsqlDbType.Text },
             { "_excludeConfirmedBy", NpgsqlDbType.Jsonb | NpgsqlDbType.Array },
+            { "_includeElements", NpgsqlDbType.Boolean },
             { "_instanceOwner_partyId", NpgsqlDbType.Integer },
             { "_instanceOwner_partyIds", NpgsqlDbType.Integer | NpgsqlDbType.Array },
             { "_lastChanged_eq", NpgsqlDbType.TimestampTz },

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -294,6 +294,12 @@ namespace Altinn.Platform.Storage.Repository
             }
 
             queryResponse.Count = queryResponse.Instances.Count;
+            tracker.Add("Count", queryResponse.Count.ToString());
+            if (tracker.ElapsedMilliseconds > 500)
+            {
+                tracker.Add("Call", FormatManualFunctionCall(postgresParams));
+            }
+
             tracker.Track();
             return queryResponse;
         }

--- a/src/Storage/Repository/TelemetryTracker.cs
+++ b/src/Storage/Repository/TelemetryTracker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using Microsoft.ApplicationInsights;
 using Npgsql;
 
@@ -48,13 +49,13 @@ namespace Altinn.Platform.Storage.Repository
             string properties = null;
             if (_props.Count > 0)
             {
-                properties = " ";
+                StringBuilder propertiesBuilder = new(" ");
                 foreach (var prop in _props)
                 {
-                    properties += $"{prop.Key}: {prop.Value}; ";
+                    propertiesBuilder.Append($"{prop.Key}: {prop.Value}; ");
                 }
 
-                properties = properties[..^2];
+                properties = propertiesBuilder.ToString()[..^2];
             }
 
             _telemetryClient?.TrackDependency("Postgres", _cmd.CommandText, properties, _startTime, _timer.Elapsed, success);

--- a/src/Storage/Repository/TelemetryTracker.cs
+++ b/src/Storage/Repository/TelemetryTracker.cs
@@ -8,24 +8,18 @@ namespace Altinn.Platform.Storage.Repository
     /// <summary>
     /// Helper to track application insights dependencies for PostgreSQL invocations
     /// </summary>
-    public class TelemetryTracker : IDisposable
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="TelemetryTracker"/> class.
+    /// </remarks>
+    /// <param name="telemetryClient">Telemetry client from DI</param>
+    /// <param name="cmd">The npgsql cmd</param>
+    public class TelemetryTracker(TelemetryClient telemetryClient, NpgsqlCommand cmd) : IDisposable
     {
         private readonly DateTime _startTime = DateTime.Now;
         private readonly Stopwatch _timer = Stopwatch.StartNew();
-        private readonly TelemetryClient _telemetryClient;
-        private readonly NpgsqlCommand _cmd;
+        private readonly TelemetryClient _telemetryClient = telemetryClient;
+        private readonly NpgsqlCommand _cmd = cmd;
         private bool _tracked = false;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TelemetryTracker"/> class.
-        /// </summary>
-        /// <param name="telemetryClient">Telemetry client from DI</param>
-        /// <param name="cmd">The npgsql cmd</param>
-        public TelemetryTracker(TelemetryClient telemetryClient, NpgsqlCommand cmd)
-        {
-            _telemetryClient = telemetryClient;
-            _cmd = cmd;
-        }
 
         /// <inheritdoc/>
         public void Dispose()

--- a/test/UnitTest/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/UnitTest/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -202,7 +202,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks
 
             if (!resourceAttributeComplete)
             {
-                (Instance instanceData, _) = await _instanceService.GetOne(Guid.Parse(resourceAttributes.InstanceValue.Split('/')[1]));
+                (Instance instanceData, _) = await _instanceService.GetOne(Guid.Parse(resourceAttributes.InstanceValue.Split('/')[1]), true);
 
                 if (instanceData != null)
                 {

--- a/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
@@ -78,7 +78,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
                 throw new RepositoryException("Data element not found", System.Net.HttpStatusCode.NotFound);
             }
 
-            foreach (var entry in propertyList)
+            foreach (var entry in propertylist)
             {
                 if (entry.Key == "/fileScanResult")
                 {

--- a/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/DataRepositoryMock.cs
@@ -61,7 +61,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return null;
         }
 
-        public async Task<DataElement> Update(Guid instanceGuid, Guid dataElementId, Dictionary<string, object> propertyList)
+        public async Task<DataElement> Update(Guid instanceGuid, Guid dataElementId, Dictionary<string, object> propertylist)
         {
             DataElement dataElement = null;
             if (_tempRepository.TryGetValue(dataElementId.ToString(), out string serializedDataElement))

--- a/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -46,7 +46,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             throw new NotImplementedException();
         }
 
-        public Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size)
+        public Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size, bool includeDataelements)
         {
             List<string> validQueryParams = new List<string>
             {

--- a/test/UnitTest/TestData/TestData.cs
+++ b/test/UnitTest/TestData/TestData.cs
@@ -15,7 +15,7 @@ namespace Altinn.Platform.Storage.UnitTest
 
         public static string UserId_2 { get; set; } = "20000001";
 
-        public static string Org_1 { get; set; } = "TDD";
+        public static string Org_1 { get; set; } = "TTD";
 
         public static string Org_2 { get; set; } = "SPF";
 

--- a/test/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -528,7 +528,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 It.Is<Dictionary<string, StringValues>>(
                     dict => dict.GetValueOrDefault("status.isHardDeleted").Single(v => v.Equals("false")) != null),
                 It.IsAny<string>(),
-                It.IsAny<int>()))
+                It.IsAny<int>(),
+                It.IsAny<bool>()))
             .ReturnsAsync(new InstanceQueryResponse { Instances = new() });
 
             string requestUri = $"{BasePath}?instanceOwner.partyId=1337";
@@ -558,7 +559,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 It.Is<Dictionary<string, StringValues>>(
                     dict => dict.GetValueOrDefault("status.isHardDeleted").Single(v => v.Equals("false")) != null),
                 It.IsAny<string>(),
-                It.IsAny<int>()))
+                It.IsAny<int>(),
+                It.IsAny<bool>()))
             .ReturnsAsync(new InstanceQueryResponse { Instances = new() });
 
             string requestUri = $"{BasePath}?instanceOwner.partyId=1337&continuationToken=thisIsTheFirstToken";

--- a/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -609,8 +609,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             string expectedIsSoftDeleted = "false";
@@ -650,8 +650,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             string expectedIsSoftDeleted = "false";
@@ -692,8 +692,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
             int expectedParamCount = 3;
 
@@ -729,8 +729,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             int expectedParamCount = 4;
@@ -771,8 +771,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             int expectedParamCount = 4;
@@ -809,7 +809,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Arrange
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             int expectedCount = 0;
@@ -845,7 +845,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Arrange
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             int expectedCount = 0;
@@ -865,7 +865,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
             Assert.Equal(expectedCount, actual.Count);
             instanceRepositoryMock.Verify(
-                ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()),
+                ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()),
                 Times.Never);
         }
 
@@ -884,8 +884,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
             string expectedAppId = "tdd/endring-av-navn";
 
@@ -922,8 +922,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
             int expectedCount = 3;
 
@@ -994,8 +994,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             HttpClient client = GetTestClient(instanceRepositoryMock);
@@ -1029,8 +1029,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Dictionary<string, StringValues> actual = new Dictionary<string, StringValues>();
             Mock<IInstanceRepository> instanceRepositoryMock = new Mock<IInstanceRepository>();
             instanceRepositoryMock
-                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>()))
-                .Callback<Dictionary<string, StringValues>, string, int>((query, cont, size) => { actual = query; })
+                .Setup(ir => ir.GetInstancesFromQuery(It.IsAny<Dictionary<string, StringValues>>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>()))
+                .Callback<Dictionary<string, StringValues>, string, int, bool>((query, cont, size, includeDataelements) => { actual = query; })
                 .ReturnsAsync((InstanceQueryResponse)null);
 
             HttpClient client = GetTestClient(instanceRepositoryMock);

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -223,7 +223,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
         private async Task<Instance> InsertInstanceAndData(Instance instance, DataElement dataelement)
         {
             instance = await _instanceFixture.InstanceRepo.Create(instance);
-            (_, long internalId) = await _instanceFixture.InstanceRepo.GetOne(Guid.Parse(instance.Id.Split('/').Last()));
+            (_, long internalId) = await _instanceFixture.InstanceRepo.GetOne(Guid.Parse(instance.Id.Split('/').Last()), true);
             await _instanceFixture.DataRepo.Create(dataelement, internalId);
             return instance;
         }

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -158,9 +158,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             Dictionary<string, StringValues> queryParams = new();
 
             // Act
-            var instances3 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100);
+            var instances3 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100, true);
             queryParams.Add("instanceOwner.partyId", new StringValues(TestData.Instance_1_3.InstanceOwner.PartyId));
-            var instances1 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100);
+            var instances1 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100, true);
 
             // Assert
             Assert.Equal(3, instances3.Count);
@@ -177,10 +177,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             await _instanceFixture.InstanceRepo.Create(TestData.Instance_1_1.Clone());
 
             Dictionary<string, StringValues> queryParams = new();
+            queryParams.Add("appId", new StringValues("ttd/test-applikasjon-1"));
 
             // Act
-            var instances = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100);
-            queryParams.Add("appId", new StringValues("test-applikasjon-1"));
+            var instances = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100, true);
 
             // Assert
             Assert.Equal(1, instances.Count);
@@ -202,7 +202,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             // Act
             queryParams.Add("instanceOwner.partyId", new StringValues(TestData.Instance_1_3.InstanceOwner.PartyId));
             queryParams.Add("process.ended", new StringValues("true"));
-            var instances = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100);
+            var instances = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 100, true);
 
             // Assert
             Assert.Equal(0, instances.Count);

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -168,6 +168,38 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
         }
 
         /// <summary>
+        /// Test GetInstancesFromQuery with continuation token
+        /// </summary>
+        [Fact]
+        public async Task Instance_GetInstancesFromQuery_Continuation_Ok()
+        {
+            // Arrange
+            await _instanceFixture.InstanceRepo.Create(TestData.Instance_1_1.Clone());
+            await _instanceFixture.InstanceRepo.Create(TestData.Instance_1_2.Clone());
+            await _instanceFixture.InstanceRepo.Create(TestData.Instance_1_3.Clone());
+            Dictionary<string, StringValues> queryParams = new();
+            queryParams.Add("sortBy", new StringValues("asc:"));
+
+            // Act
+            var instances1 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, null, 1, true);
+            string contToken1 = instances1.ContinuationToken;
+            var instances2 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, contToken1, 1, true);
+            string contToken2 = instances2.ContinuationToken;
+            var instances3 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(queryParams, contToken2, 2, true);
+            string contToken3 = instances3.ContinuationToken;
+
+            // Assert
+            Assert.Equal(1, instances1.Count);
+            Assert.Equal(1, instances2.Count);
+            Assert.Equal(1, instances3.Count);
+            Assert.Null(contToken3);
+            Assert.True(string.CompareOrdinal(contToken1, contToken2) < 0);
+            Assert.Equal(instances1.Instances.FirstOrDefault().Id, TestData.Instance_1_1.Id);
+            Assert.Equal(instances2.Instances.FirstOrDefault().Id, TestData.Instance_1_2.Id);
+            Assert.Equal(instances3.Instances.FirstOrDefault().Id, TestData.Instance_1_3.Id);
+        }
+
+        /// <summary>
         /// Test GetInstancesFromQuery
         /// </summary>
         [Fact]


### PR DESCRIPTION
- Added includeDataelements as parameter to GetInstancesFromQuery. Should be false from sbl message box search.
- Made parameter includeElements in IInstanceRepository.GetOne mandatory
- Changed GetMessageBoxInstance to not get elements
- Avoid updating read status if status is unchanged
- Removed SetStatues (previous PR ensure statuses maintained for data element create/write/delete)
- Reduced number of warnings and info messages
- Added unit test for continuation token
- Added more logging functionality to TelemetryTracker
- Added logging to GetInstancesFromQuery
- Added null-check in GetSBLStatusForCurrentTask

