### PR TITLE
Set DependencyTelemetry sampling % to 100 and fix update of instance lastChanged

### DIFF
--- a/src/Storage/Configuration/CustomTelemetryInitializer.cs
+++ b/src/Storage/Configuration/CustomTelemetryInitializer.cs
@@ -20,13 +20,13 @@ namespace Altinn.Platform.Telemetry
                 telemetry.Context.Cloud.RoleName = "platform-storage";
             }
 
-            // Disable sampling for exceptions, requests, failed dependencies and cleanup
+            // Disable sampling for exceptions, requests, dependencies and cleanup
             if (telemetry is RequestTelemetry requestTelemetry)
             {
                 ((ISupportSampling)telemetry).SamplingPercentage = 100;
                 requestTelemetry.ProactiveSamplingDecision = SamplingDecision.SampledIn;
             }
-            else if (telemetry is DependencyTelemetry dependencyTelemetry && !(dependencyTelemetry.Success ?? true))
+            else if (telemetry is DependencyTelemetry dependencyTelemetry)
             {
                 ((ISupportSampling)telemetry).SamplingPercentage = 100;
                 dependencyTelemetry.ProactiveSamplingDecision = SamplingDecision.SampledIn;

--- a/src/Storage/Migration/v0.04/01-setup-functions.sql
+++ b/src/Storage/Migration/v0.04/01-setup-functions.sql
@@ -1,9 +1,10 @@
-CREATE OR REPLACE PROCEDURE storage.insertdataelement(
+CREATE OR REPLACE FUNCTION storage.insertdataelement_v2(
 	IN _instanceinternalid bigint,
 	IN _instanceguid uuid,
 	IN _alternateid uuid,
 	IN _element jsonb)
-LANGUAGE plpgsql
+    RETURNS TABLE (updatedElement JSONB)
+    LANGUAGE plpgsql
 AS $BODY$
 BEGIN
     -- Make sure that lastChanged has the Postgres precision (6 digits). The timestamp from C# DateTime and then json serialize has 7 digits
@@ -22,7 +23,9 @@ BEGIN
                 || jsonb_set('{"LastChangedBy":""}', '{LastChangedBy}', to_jsonb(_element ->> 'LastChangedBy'))
         WHERE id = _instanceinternalid;
 
-    INSERT INTO storage.dataelements(instanceinternalid, instanceGuid, alternateid, element) VALUES (_instanceinternalid, _instanceGuid, _alternateid, jsonb_strip_nulls(_element));
+    RETURN QUERY
+        INSERT INTO storage.dataelements(instanceinternalid, instanceGuid, alternateid, element) VALUES (_instanceinternalid, _instanceGuid, _alternateid, jsonb_strip_nulls(_element))
+            RETURNING element;
 END;
 $BODY$;
 
@@ -30,11 +33,14 @@ CREATE OR REPLACE FUNCTION storage.updatedataelement_v2(_dataelementGuid UUID, _
     RETURNS TABLE (updatedElement JSONB)
     LANGUAGE 'plpgsql'	
 AS $BODY$
+DECLARE
+    _lastChanged6digits TEXT;
 BEGIN
     IF _lastChanged IS NOT NULL
     THEN
         -- Make sure that lastChanged has the Postgres precision (6 digits). The timestamp from C# DateTime and then json serialize has 7 digits
-        _elementChanges := _elementChanges || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(REPLACE((_lastChanged AT TIME ZONE 'UTC')::TEXT, ' ', 'T') || 'Z'));
+        _lastChanged6digits = REPLACE((_lastChanged AT TIME ZONE 'UTC')::TEXT, ' ', 'T') || 'Z';
+        _elementChanges := _elementChanges || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(_lastChanged6digits));
     END IF;
 
     IF _isReadChangedToFalse = true AND
@@ -50,7 +56,7 @@ BEGIN
     THEN
         UPDATE storage.instances
             SET lastchanged = _lastChanged,
-                instance = instance || _instanceChanges           
+                instance = instance || _instanceChanges || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(_lastChanged6digits))   
             WHERE alternateid = _instanceGuid;
     END IF;
 

--- a/src/Storage/Migration/v0.04/01-setup-functions.sql
+++ b/src/Storage/Migration/v0.04/01-setup-functions.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE PROCEDURE storage.insertdataelement(
+	IN _instanceinternalid bigint,
+	IN _instanceguid uuid,
+	IN _alternateid uuid,
+	IN _element jsonb)
+LANGUAGE plpgsql
+AS $BODY$
+BEGIN
+    -- Make sure that lastChanged has the Postgres precision (6 digits). The timestamp from C# DateTime and then json serialize has 7 digits
+    _element := _element || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(REPLACE(((_element ->> 'LastChanged')::TIMESTAMPTZ AT TIME ZONE 'UTC')::TEXT, ' ', 'T') || 'Z'));
+
+    IF _element ->> 'IsRead' = 'false' THEN
+        UPDATE storage.instances
+        SET instance = jsonb_set(instance, '{Status, ReadStatus}', '2')
+        WHERE id = _instanceinternalid AND instance -> 'Status' ->> 'ReadStatus' = '1';
+    END IF;
+
+    UPDATE storage.instances
+        SET lastchanged = (_element ->> 'LastChanged')::TIMESTAMPTZ,
+            instance = instance
+                || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(_element ->> 'LastChanged'))
+                || jsonb_set('{"LastChangedBy":""}', '{LastChangedBy}', to_jsonb(_element ->> 'LastChangedBy'))
+        WHERE id = _instanceinternalid;
+
+    INSERT INTO storage.dataelements(instanceinternalid, instanceGuid, alternateid, element) VALUES (_instanceinternalid, _instanceGuid, _alternateid, jsonb_strip_nulls(_element));
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION storage.updatedataelement_v2(_dataelementGuid UUID, _instanceGuid UUID, _elementChanges JSONB, _instanceChanges JSONB, _isReadChangedToFalse BOOL, _lastChanged TIMESTAMPTZ)
+    RETURNS TABLE (updatedElement JSONB)
+    LANGUAGE 'plpgsql'	
+AS $BODY$
+BEGIN
+    IF _lastChanged IS NOT NULL
+    THEN
+        -- Make sure that lastChanged has the Postgres precision (6 digits). The timestamp from C# DateTime and then json serialize has 7 digits
+        _elementChanges := _elementChanges || jsonb_set('{"LastChanged":""}', '{LastChanged}', to_jsonb(REPLACE((_lastChanged AT TIME ZONE 'UTC')::TEXT, ' ', 'T') || 'Z'));
+    END IF;
+
+    IF _isReadChangedToFalse = true AND
+        (SELECT COUNT(*) FROM storage.dataelements
+            WHERE element -> 'IsRead' = 'true' AND instanceguid = _instanceGuid AND alternateid <> _dataelementGuid) = 0
+    THEN
+        UPDATE storage.instances
+        SET instance = jsonb_set(instance, '{Status, ReadStatus}', '0')
+        WHERE alternateid = _instanceGuid AND instance -> 'Status' ->> 'ReadStatus' = '1';
+    END IF;
+
+    IF _lastChanged IS NOT NULL
+    THEN
+        UPDATE storage.instances
+            SET lastchanged = _lastChanged,
+                instance = instance || _instanceChanges           
+            WHERE alternateid = _instanceGuid;
+    END IF;
+
+    RETURN QUERY
+        UPDATE storage.dataelements SET element = element || _elementChanges WHERE alternateid = _dataelementGuid
+            RETURNING element;
+END;
+$BODY$;

--- a/src/Storage/Repository/PgDataRepository.cs
+++ b/src/Storage/Repository/PgDataRepository.cs
@@ -28,7 +28,7 @@ namespace Altinn.Platform.Storage.Repository
         NpgsqlDataSource dataSource,
         TelemetryClient telemetryClient = null) : IDataRepository
     {
-        private readonly string _insertSql = "call storage.insertdataelement ($1, $2, $3, $4)";
+        private readonly string _insertSql = "select * from storage.insertdataelement_v2 ($1, $2, $3, $4)";
         private readonly string _readSql = "select * from storage.readdataelement($1)";
         private readonly string _deleteSql = "select * from storage.deletedataelement_v2 ($1, $2, $3)";
         private readonly string _deleteForInstanceSql = "select * from storage.deletedataelements ($1)";
@@ -49,7 +49,11 @@ namespace Altinn.Platform.Storage.Repository
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, new Guid(dataElement.Id));
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Jsonb, dataElement);
 
-            await pgcom.ExecuteNonQueryAsync();
+            await using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                dataElement = reader.GetFieldValue<DataElement>("updatedElement");
+            }
 
             tracker.Track();
             return dataElement;

--- a/src/Storage/Repository/PgDataRepository.cs
+++ b/src/Storage/Repository/PgDataRepository.cs
@@ -118,7 +118,6 @@ namespace Altinn.Platform.Storage.Repository
             List<string> elementProperties = [];
             List<string> instanceProperties = [];
             DataElement element = new();
-            Instance lastChangedWrapper = new();
             bool isReadChangedToFalse = false;
             foreach (var kvp in propertylist)
             {
@@ -140,6 +139,7 @@ namespace Altinn.Platform.Storage.Repository
                 }
             }
 
+            Instance lastChangedWrapper = new() { LastChanged = element.LastChanged, LastChangedBy = element.LastChangedBy };
             await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_updateSql);
             using TelemetryTracker tracker = new(_telemetryClient, pgcom);
 


### PR DESCRIPTION
- Converted lastChanged so that the precision is always 6 digits
- Corrected bug in PgDataRepository: Instance object wasn't populated
- Set DependencyTelemetry sampling % to 100
- Changed storage.insertdataelement from procedure to function to return updated dataelement.
- Changed storage.updatedataelement_v2 so that lastChanged json property gets av value with 6 digits. Also updated PgDataRepository to reflect the updated element
- Added functionality to unit tests for data element create and update to check the updated lastchanged values in instance and dataelement