### PR TITLE
Changed updating of instance from read and update in different transactions to atomic update with json merge.

### DIFF
--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -221,6 +221,12 @@ namespace Altinn.Platform.Storage.Controllers
             }
             else if (instance.Status.IsSoftDeleted)
             {
+                List<string> updateProperties = [];
+                updateProperties.Add(nameof(instance.LastChanged));
+                updateProperties.Add(nameof(instance.LastChangedBy));
+                updateProperties.Add(nameof(instance.Status));
+                updateProperties.Add(nameof(instance.Status.IsSoftDeleted));
+                updateProperties.Add(nameof(instance.Status.SoftDeleted));
                 instance.LastChangedBy = User.GetUserOrOrgId();
                 instance.LastChanged = DateTime.UtcNow;
                 instance.Status.IsSoftDeleted = false;
@@ -240,7 +246,7 @@ namespace Altinn.Platform.Storage.Controllers
                     }
                 };
 
-                await _instanceRepository.Update(instance);
+                await _instanceRepository.Update(instance, updateProperties);
                 await _instanceEventRepository.InsertInstanceEvent(instanceEvent);
                 return Ok(true);
             }
@@ -272,12 +278,18 @@ namespace Altinn.Platform.Storage.Controllers
 
             instance.Status ??= new InstanceStatus();
 
+            List<string> updateProperties = [];
+            updateProperties.Add(nameof(instance.Status));
+            updateProperties.Add(nameof(instance.Status.IsSoftDeleted));
+            updateProperties.Add(nameof(instance.Status.SoftDeleted));
             if (hard)
             {
                 instance.Status.IsHardDeleted = true;
                 instance.Status.IsSoftDeleted = true;
                 instance.Status.HardDeleted = now;
                 instance.Status.SoftDeleted ??= now;
+                updateProperties.Add(nameof(instance.Status.IsHardDeleted));
+                updateProperties.Add(nameof(instance.Status.HardDeleted));
             }
             else
             {
@@ -287,6 +299,8 @@ namespace Altinn.Platform.Storage.Controllers
 
             instance.LastChangedBy = User.GetUserOrOrgId();
             instance.LastChanged = now;
+            updateProperties.Add(nameof(instance.LastChanged));
+            updateProperties.Add(nameof(instance.LastChangedBy));
 
             InstanceEvent instanceEvent = new InstanceEvent
             {
@@ -302,7 +316,7 @@ namespace Altinn.Platform.Storage.Controllers
                 },
             };
 
-            await _instanceRepository.Update(instance);
+            await _instanceRepository.Update(instance, updateProperties);
             await _instanceEventRepository.InsertInstanceEvent(instanceEvent);
 
             return Ok(true);

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -116,11 +116,34 @@ namespace Altinn.Platform.Storage.Controllers
             }
 
             // Archiving instance if process was ended
+            List<string> updateProperties = [
+                nameof(existingInstance.Process),
+                nameof(existingInstance.Process.CurrentTask),
+                nameof(existingInstance.Process.CurrentTask.AltinnTaskType),
+                nameof(existingInstance.Process.CurrentTask.ElementId),
+                nameof(existingInstance.Process.CurrentTask.Ended),
+                nameof(existingInstance.Process.CurrentTask.Flow),
+                nameof(existingInstance.Process.CurrentTask.FlowType),
+                nameof(existingInstance.Process.CurrentTask.Name),
+                nameof(existingInstance.Process.CurrentTask.Started),
+                nameof(existingInstance.Process.CurrentTask.Validated),
+                nameof(existingInstance.Process.CurrentTask.Validated.Timestamp),
+                nameof(existingInstance.Process.CurrentTask.Validated.CanCompleteTask),
+                nameof(existingInstance.Process.Ended),
+                nameof(existingInstance.Process.EndEvent),
+                nameof(existingInstance.Process.Started),
+                nameof(existingInstance.Process.StartEvent),
+                nameof(existingInstance.LastChanged),
+                nameof(existingInstance.LastChangedBy)
+            ];
             if (existingInstance.Process.Ended == null && processState?.Ended != null)
             {
                 existingInstance.Status ??= new InstanceStatus();
                 existingInstance.Status.IsArchived = true;
                 existingInstance.Status.Archived = processState.Ended;
+                updateProperties.Add(nameof(existingInstance.Status));
+                updateProperties.Add(nameof(existingInstance.Status.IsArchived));
+                updateProperties.Add(nameof(existingInstance.Status.Archived));
             }
 
             existingInstance.Process = processState;
@@ -129,7 +152,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             Instance updatedInstance;
 
-            updatedInstance = await _instanceRepository.Update(existingInstance);
+            updatedInstance = await _instanceRepository.Update(existingInstance, updateProperties);
 
             if (processState?.CurrentTask?.AltinnTaskType == "signing")
             {

--- a/src/Storage/Migration/v0.05/01-setup-functions.sql
+++ b/src/Storage/Migration/v0.05/01-setup-functions.sql
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION storage.updateinstance(_alternateid UUID, _instance JSONB, _datavalues JSONB, _completeconfirmations JSONB, _lastchanged TIMESTAMPTZ, _taskid TEXT)
+    RETURNS TABLE (updatedInstance JSONB)
+    LANGUAGE 'plpgsql'	
+AS $BODY$
+BEGIN
+    IF _datavalues IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _instance ||
+                    jsonb_set(
+                        '{"DataValues":""}',
+                        '{DataValues}',
+                        CASE WHEN instance -> 'DataValues' IS NOT NULL THEN
+                            instance -> 'DataValues' || _datavalues
+                        ELSE
+                            _datavalues
+                        END
+                    ),
+                lastchanged = _lastchanged,
+                taskid = _taskid
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _completeconfirmations IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _instance ||
+                    jsonb_set(
+                        '{"CompleteConfirmations":""}',
+                        '{CompleteConfirmations}',
+                        CASE WHEN instance -> 'CompleteConfirmations' IS NOT NULL THEN
+                            instance -> 'CompleteConfirmations' || _completeconfirmations
+                        ELSE
+                            _completeconfirmations
+                        END
+                    ),
+                lastchanged = _lastchanged,
+                taskid = _taskid
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSE
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _instance,
+                lastchanged = _lastchanged,
+                taskid = _taskid
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    END IF;
+END;
+$BODY$;

--- a/src/Storage/Repository/IInstanceRepository.cs
+++ b/src/Storage/Repository/IInstanceRepository.cs
@@ -40,8 +40,9 @@ namespace Altinn.Platform.Storage.Repository
         /// update existing instance
         /// </summary>
         /// <param name="instance">the instance to update</param>
+        /// <param name="updateProperties">a list of which properties should be updated</param>
         /// <returns>The updated instance</returns>
-        Task<Instance> Update(Instance instance);
+        Task<Instance> Update(Instance instance, List<string> updateProperties);
 
         /// <summary>
         /// Delets an instance.

--- a/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -162,7 +162,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return Task.FromResult<(Instance, long)>((null, 0));
         }
 
-        public Task<Instance> Update(Instance instance)
+        public Task<Instance> Update(Instance instance, List<string> updateProperties)
         {
             if (instance.Id.Equals("1337/d3b326de-2dd8-49a1-834a-b1d23b11e540"))
             {

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -257,7 +258,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IInstanceRepository> repositoryMock = new Mock<IInstanceRepository>();
             repositoryMock.Setup(ir => ir.GetOne(It.IsAny<Guid>(), true)).ReturnsAsync((testInstance, 0));
-            repositoryMock.Setup(ir => ir.Update(It.IsAny<Instance>())).ReturnsAsync((Instance i) => i);
+            repositoryMock.Setup(ir => ir.Update(It.IsAny<Instance>(), It.IsAny<List<string>>())).ReturnsAsync((Instance i, List<string> props) => i);
 
             HttpClient client = GetTestClient(repositoryMock.Object);
             string token = PrincipalUtil.GetToken(3, 1337, 3);

--- a/test/UnitTest/TestingRepositories/DataTests.cs
+++ b/test/UnitTest/TestingRepositories/DataTests.cs
@@ -28,6 +28,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             string sql = "delete from storage.instances; delete from storage.dataelements;";
             _ = PostgresUtil.RunSql(sql).Result;
             Instance instance = TestData.Instance_1_1.Clone();
+            instance.Status.IsSoftDeleted = true;
             Instance newInstance = _dataElementFixture.InstanceRepo.Create(instance).Result;
             (_instance, _instanceInternalId) = _dataElementFixture.InstanceRepo.GetOne(Guid.Parse(newInstance.Id.Split('/').Last()), false).Result;
         }


### PR DESCRIPTION
Updating of DataValues and ConfirmConfirmations must be treated specially because the postgres json merge operator (||) doesn't support merging of objects/arrays (the right operand overwrites values in the left operand).

Unit tests are added to verify different update combinations.