### PR TITLE
Changed instance update to reflect various json merge needs

### DIFF
--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -610,10 +610,7 @@ namespace Altinn.Platform.Storage.Controllers
             try
             {
                 List<string> updateProperties = [
-                    nameof(instance.Status),
                     nameof(instance.Status.Substatus),
-                    nameof(instance.Status.Substatus.Description),
-                    nameof(instance.Status.Substatus.Label),
                     nameof(instance.LastChanged),
                     nameof(instance.LastChangedBy)
                 ];

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -118,21 +118,6 @@ namespace Altinn.Platform.Storage.Controllers
             // Archiving instance if process was ended
             List<string> updateProperties = [
                 nameof(existingInstance.Process),
-                nameof(existingInstance.Process.CurrentTask),
-                nameof(existingInstance.Process.CurrentTask.AltinnTaskType),
-                nameof(existingInstance.Process.CurrentTask.ElementId),
-                nameof(existingInstance.Process.CurrentTask.Ended),
-                nameof(existingInstance.Process.CurrentTask.Flow),
-                nameof(existingInstance.Process.CurrentTask.FlowType),
-                nameof(existingInstance.Process.CurrentTask.Name),
-                nameof(existingInstance.Process.CurrentTask.Started),
-                nameof(existingInstance.Process.CurrentTask.Validated),
-                nameof(existingInstance.Process.CurrentTask.Validated.Timestamp),
-                nameof(existingInstance.Process.CurrentTask.Validated.CanCompleteTask),
-                nameof(existingInstance.Process.Ended),
-                nameof(existingInstance.Process.EndEvent),
-                nameof(existingInstance.Process.Started),
-                nameof(existingInstance.Process.StartEvent),
                 nameof(existingInstance.LastChanged),
                 nameof(existingInstance.LastChangedBy)
             ];

--- a/src/Storage/Migration/v0.06/01-functions-and-procedures.sql
+++ b/src/Storage/Migration/v0.06/01-functions-and-procedures.sql
@@ -1,0 +1,135 @@
+CREATE OR REPLACE FUNCTION storage.updateinstance_v2(
+        _alternateid UUID,
+        _toplevelsimpleprops JSONB,
+        _datavalues JSONB,
+        _completeconfirmations JSONB,
+        _presentationtexts JSONB,
+        _status JSONB,
+        _substatus JSONB,
+        _process JSONB,
+        _lastchanged TIMESTAMPTZ,
+        _taskid TEXT)
+    RETURNS TABLE (updatedInstance JSONB)
+    LANGUAGE 'plpgsql'	
+AS $BODY$
+BEGIN
+    IF _datavalues IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _toplevelsimpleprops ||
+                    jsonb_strip_nulls(
+                        jsonb_set(
+                            '{"DataValues":""}',
+                            '{DataValues}',
+                            CASE WHEN instance -> 'DataValues' IS NOT NULL THEN
+                                instance -> 'DataValues' || _datavalues
+                            ELSE
+                                _datavalues
+                            END
+                        )
+                    ),
+                lastchanged = _lastchanged
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _presentationtexts IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _toplevelsimpleprops ||
+                    jsonb_strip_nulls(
+                        jsonb_set(
+                            '{"PresentationTexts":""}',
+                            '{PresentationTexts}',
+                            CASE WHEN instance -> 'PresentationTexts' IS NOT NULL THEN
+                                instance -> 'PresentationTexts' || _presentationtexts
+                            ELSE
+                                _presentationtexts
+                            END
+                        )
+                    ),
+                lastchanged = _lastchanged
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _completeconfirmations IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance || _toplevelsimpleprops ||
+                    jsonb_set(
+                        '{"CompleteConfirmations":""}',
+                        '{CompleteConfirmations}',
+                        CASE WHEN instance -> 'CompleteConfirmations' IS NOT NULL THEN
+                            instance -> 'CompleteConfirmations' || _completeconfirmations
+                        ELSE
+                            _completeconfirmations
+                        END
+                    ),
+                lastchanged = _lastchanged
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _status IS NOT NULL AND _process IS NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance ||
+                    jsonb_set(
+                        instance || _toplevelsimpleprops,
+                        '{Status}',
+                        CASE WHEN instance -> 'Status' IS NOT NULL THEN
+                            instance -> 'Status' || _status
+                        ELSE
+                            _status
+                        END
+                    ),
+                lastchanged = _lastchanged
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _substatus IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance ||
+                    jsonb_set(
+                        instance || _toplevelsimpleprops,
+                        '{Status, Substatus}',
+                        jsonb_strip_nulls(_substatus)
+                    ),
+                lastchanged = _lastchanged
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _process IS NOT NULL AND _status IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance ||
+                    jsonb_set(
+                        instance || _toplevelsimpleprops,
+                        '{Process}',
+                        jsonb_strip_nulls(_process)
+                    ) ||
+                    jsonb_set(
+                        '{"Status":""}',
+                        '{Status}',
+                        CASE WHEN instance -> 'Status' IS NOT NULL THEN
+                            instance -> 'Status' || _status
+                        ELSE
+                            _status
+                        END
+                    ),                
+                lastchanged = _lastchanged,
+                taskid = _taskid
+            WHERE _alternateid = alternateid
+            RETURNING instance;
+    ELSIF _process IS NOT NULL THEN
+        RETURN QUERY
+            UPDATE storage.instances SET
+                instance = instance ||
+                    jsonb_set(
+                        instance || _toplevelsimpleprops,
+                        '{Process}',
+                        jsonb_strip_nulls(_process)
+                    ),               
+                lastchanged = _lastchanged,
+                taskid = _taskid
+            WHERE _alternateid = alternateid
+            RETURNING instance;                
+    ELSE
+        RAISE EXCEPTION 'Unexpected parameters to update instance';
+    END IF;
+END;
+$BODY$;

--- a/test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
+++ b/test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
@@ -174,4 +174,10 @@
     <_ContentIncludedByDefault Remove="data\roles\user_5\party_1337\roles.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Changed instance update to reflect various json merge needs. Cases:
- Process: Insert complete json
- Substatus: Insert complete json
- Status: Merge propertis based on updateProperties in repo api
- CompleteConfirmations: Merge properties
- Datavalues: Merge properties
- PresentationTexts: Merge properties
- Other top level properties (lastchanged and lastchangedby): Merge properties
- "Complications": Process and Substatus might be combined, and the different combinations must be treated separately

## Related Issue(s)
- #331

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
