### PR TITLE
#3 Cookie name reverted and profile endpoint property removed

### DIFF
--- a/src/Storage/Configuration/GeneralSettings.cs
+++ b/src/Storage/Configuration/GeneralSettings.cs
@@ -47,10 +47,5 @@ namespace Altinn.Platform.Storage.Configuration
         /// Gets or sets the cache lifetime for application metadata document.
         /// </summary>
         public int AppMetadataCacheLifeTimeInSeconds { get; set; }
-
-        /// <summary>
-        /// Name of the cookie for where JWT is stored
-        /// </summary>
-        public string JwtCookieName { get; set; }
     }
 }

--- a/src/Storage/Configuration/PlatformSettings.cs
+++ b/src/Storage/Configuration/PlatformSettings.cs
@@ -14,11 +14,6 @@ namespace Altinn.Platform.Storage.Configuration
         public string ApiRegisterEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the url for the Profile API endpoint
-        /// </summary>
-        public string ApiProfileEndpoint { get; set; }
-
-        /// <summary>
         /// Gets or sets the apps domain used to match events source
         /// </summary>
         public string AppsDomain { get; set; }

--- a/src/Storage/Services/RegisterService.cs
+++ b/src/Storage/Services/RegisterService.cs
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Storage.Services
             Party party = null;
 
             string endpointUrl = $"parties/{partyId}";
-            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.JwtCookieName);
+            string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.RuntimeCookieName);
             string accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "events");
 
             HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
@@ -91,7 +91,7 @@ namespace Altinn.Platform.Storage.Services
 
             PartyLookup partyLookup = new PartyLookup() { Ssn = person, OrgNo = orgNo };
 
-            string bearerToken = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.JwtCookieName);
+            string bearerToken = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.RuntimeCookieName);
             string accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "storage");
 
             StringContent content = new StringContent(JsonSerializer.Serialize(partyLookup));

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -26,7 +26,6 @@
     "TextResourceCacheLifeTimeInSeconds": 3600,
     "AppTitleCacheLifeTimeInSeconds": 3600,
     "AppMetadataCacheLifeTimeInSeconds": 300,
-    "JwtCookieName": "AltinnStudioRuntime",
     "InstanceReadScope": [ "altinn:serviceowner/instances.read" ]
   },
   "PlatformSettings": {

--- a/test/UnitTest/TestingServices/RegisterServiceTest.cs
+++ b/test/UnitTest/TestingServices/RegisterServiceTest.cs
@@ -202,7 +202,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             GeneralSettings generalSettings = new GeneralSettings
             {
-                JwtCookieName = "AltinnStudioRuntime"
+                RuntimeCookieName = "AltinnStudioRuntime"
             };
 
             _generalSettings.Setup(s => s.Value).Returns(generalSettings);

--- a/test/UnitTest/appsettings.unittest.json
+++ b/test/UnitTest/appsettings.unittest.json
@@ -25,8 +25,7 @@
     "AppTitleCacheLifeTimeInSeconds": 60,
     "AppMetadataCacheLifeTimeInSeconds": 60,
     "TextResourceCacheLifeTimeInSeconds": 60,
-    "UsePostgreSQL": "false",
-    "JwtCookieName": "AltinnStudioRuntime"
+    "UsePostgreSQL": "false"
   },
   "PlatformSettings": {
     "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",


### PR DESCRIPTION
Cookie name reverted and profile endpoint property removed

## Description
- Cookie name reverted from `JwtCookieName` to `RuntimeCookieName`
- Profile endpoint property removed form platform settings

## Related Issue(s)
- #3
- #360 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green