### PR TITLE
Add task reference to signatures [part 1/2]

### DIFF
--- a/src/Storage.Interface/Models/SignRequest.cs
+++ b/src/Storage.Interface/Models/SignRequest.cs
@@ -16,6 +16,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         public string SignatureDocumentDataType { get; set; }
 
         /// <summary>
+        /// The task which should be linked to this signature
+        /// </summary>
+        [JsonProperty(PropertyName = "generatedFromTask")]
+        public string GeneratedFromTask { get; set; } = string.Empty;
+        
+        /// <summary>
         /// List of dataElementSignatures
         /// </summary>
         [JsonProperty(PropertyName = "dataElementSignatures")]

--- a/src/Storage.Interface/Models/SignRequest.cs
+++ b/src/Storage.Interface/Models/SignRequest.cs
@@ -16,12 +16,6 @@ namespace Altinn.Platform.Storage.Interface.Models
         public string SignatureDocumentDataType { get; set; }
 
         /// <summary>
-        /// The task which should be linked to this signature
-        /// </summary>
-        [JsonProperty(PropertyName = "taskId")]
-        public string TaskId { get; set; } = string.Empty;
-        
-        /// <summary>
         /// List of dataElementSignatures
         /// </summary>
         [JsonProperty(PropertyName = "dataElementSignatures")]

--- a/src/Storage.Interface/Models/SignRequest.cs
+++ b/src/Storage.Interface/Models/SignRequest.cs
@@ -16,6 +16,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         public string SignatureDocumentDataType { get; set; }
 
         /// <summary>
+        /// The task which should be linked to this signature
+        /// </summary>
+        [JsonProperty(PropertyName = "taskId")]
+        public string TaskId { get; set; } = string.Empty;
+        
+        /// <summary>
         /// List of dataElementSignatures
         /// </summary>
         [JsonProperty(PropertyName = "dataElementSignatures")]

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                signRequest.GeneratedFromTask);
+                null);
 
             signDocument.Id = dataElement.Id;
         

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                null);
+                instance.Process.CurrentTask?.ElementId);
 
             signDocument.Id = dataElement.Id;
         

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                null);
+                signRequest.TaskId);
 
             signDocument.Id = dataElement.Id;
         

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                instance.Process.CurrentTask?.ElementId);
+                signRequest.GeneratedFromTask);
 
             signDocument.Id = dataElement.Id;
         

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                signRequest.TaskId);
+                null);
 
             signDocument.Id = dataElement.Id;
         


### PR DESCRIPTION
## Description
`DataElements` created during a signature step should be annotated with the `task` they belong to (were generated from).

Establishing the signature <-> task link enables cleanup and introspection where required, eg. to prevent a signature task from generating duplicate and/or stale signatures.

## Implementation order
This is implementation part 1 of 2, which adds an optional property called `GeneratedFromTask` to the `SignRequest` model.

## Related Issue(s)
- #351
- Altinn/app-lib-dotnet#460

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
