### PR TITLE
Improve readability for SHA256 hashing method

### DIFF
--- a/src/Storage/Services/DataService.cs
+++ b/src/Storage/Services/DataService.cs
@@ -91,8 +91,7 @@ namespace Altinn.Platform.Storage.Services
         /// <returns>String representation of the digest</returns>
         private static string FormatShaDigest(byte[] digest)
         {
-            var hexString = BitConverter.ToString(digest);
-            return hexString.Replace("-", string.Empty).ToLowerInvariant();
+            return Convert.ToHexString(digest).ToLowerInvariant();
         }
     }
 }

--- a/src/Storage/Services/DataService.cs
+++ b/src/Storage/Services/DataService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Clients;
+using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Models;
 using Altinn.Platform.Storage.Repository;
@@ -68,8 +69,9 @@ namespace Altinn.Platform.Storage.Services
                 return (null, new ServiceError(404, $"Failed reading file, dataElementId: {dataElementId}"));
             }
 
-            using SHA256 sha256 = SHA256.Create();
-            return (BitConverter.ToString(sha256.ComputeHash(filestream)).Replace("-", string.Empty).ToLowerInvariant(), null);   
+            using var sha256 = SHA256.Create();
+            var digest = await sha256.ComputeHashAsync(filestream);
+            return (FormatShaDigest(digest), null);   
         }
 
         /// <inheritdoc/>
@@ -79,6 +81,18 @@ namespace Altinn.Platform.Storage.Services
             dataElement.Size = length;
             
             await _dataRepository.Create(dataElement, instanceInternalId);
+        }
+        
+        /// <summary>
+        /// Formats a SHA digest with common best best practice:<br/>
+        /// Lowercase hexadecimal representation without delimiters
+        /// </summary>
+        /// <param name="digest">The hash code (digest) to format</param>
+        /// <returns>String representation of the digest</returns>
+        private static string FormatShaDigest(byte[] digest)
+        {
+            var hexString = BitConverter.ToString(digest);
+            return hexString.Replace("-", string.Empty).ToLowerInvariant();
         }
     }
 }

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -73,6 +73,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             Guid id = Guid.NewGuid();
             string blobStoragePath = "/ttd/some-app";
+            byte[] blobStorageBytes = "whatever"u8.ToArray();
+            string expectedHashResult = "85738f8f9a7f1b04b5329c590ebcb9e425925c6d0984089c43a022de4f19c281";
+            
             DataElement dataElement = new DataElement
             {
                 Id = id.ToString(),
@@ -82,7 +85,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             dataRepositoryMock.Setup(drm => drm.Read(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(dataElement);
             blobRepositoryMock.Setup(
                 drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath))
-                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("whatever")));
+                .ReturnsAsync(new MemoryStream(blobStorageBytes));
 
             DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
             
@@ -90,7 +93,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             (string fileHash, ServiceError serviceError) = await dataService.GenerateSha256Hash("ttd", Guid.NewGuid(), id);
 
             // Assert
-            Assert.NotNull(fileHash);
+            Assert.Equal(fileHash, expectedHashResult);
             Assert.Null(serviceError);
             dataRepositoryMock.VerifyAll();
         }


### PR DESCRIPTION
This is a simple refactor that splits out the string formatting from `DataService.GenerateSha256Hash` into a separate method. The existing implementation returs valid and appropriate data, but the readibility is quite low.

The hope is that splitting the string formatting out from the actual hashing will provide a clearer separation between these two steps, which in turn will simplify the understanding of how exactly this process works.

This PR also modifies associated testing to assert equality consistent formatting. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
  https://github.com/Altinn/altinn-studio-docs/pull/1594
