### PR TITLE
Add task reference to signatures [part 2/2]

### DIFF
--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Altinn.Common.AccessToken" Version="4.4.0" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.0.2" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.6.0" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.25.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />

--- a/src/Storage/Services/InstanceService.cs
+++ b/src/Storage/Services/InstanceService.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json", 
                 0, 
                 userId.ToString(),
-                null);
+                signRequest.GeneratedFromTask);
 
             signDocument.Id = dataElement.Id;
         


### PR DESCRIPTION
## Description
`DataElements` created during a signature step should be annotated with the `task` they belong to (were generated from).

Establishing the signature <-> task link enables cleanup and introspection where required, eg. to prevent a signature task from generating duplicate and/or stale signatures.

## Implementation order
This is implementation part 2 of 2, which passes `SignRequest.GeneratedFromTask` to `DataElementHelper.CreateDataElement`.

✅ [Part 1 was merged to main on 2024-05-13](https://github.com/Altinn/altinn-storage/pull/392), alongside the release of [Altinn.Platform.Storage.Interface version 3.25.0 ](https://github.com/Altinn/altinn-storage/releases/tag/Storage.Interface-3.25.0)

## Test results
✅ Using the test setup [described here](https://github.com/Altinn/app-lib-dotnet/pull/617), it has been confirmed that _existing_ behavior is preserved with the current builds of `app-lib-dotnet` and that _new_ expected behavior is achieved with [the proposed new feature in app-lib-dotnet](https://github.com/Altinn/app-lib-dotnet/pull/617).

## Related Issue(s)
- #351
- Altinn/app-lib-dotnet#460

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
