### PR TITLE
Add Metadata to DataElement [part 1/2].

### DIFF
--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -96,7 +96,7 @@ namespace Altinn.Platform.Storage.Interface.Models
         public List<string> Tags { get; set; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets a list of key-value pairs that can be used to store metadata.
+        /// Gets or sets a list of key-value pairs that can be used to store metadata. Can be used in custom app code to store custom metadata.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]
         public List<KeyValueEntry> Metadata { get; set; }

--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -96,6 +96,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         public List<string> Tags { get; set; } = new List<string>();
 
         /// <summary>
+        /// Gets or sets a list of key-value pairs that can be used to store metadata.
+        /// </summary>
+        [JsonProperty(PropertyName = "metadata")]
+        public List<KeyValueEntry> Metadata { get; set; }
+
+        /// <summary>
         /// Gets or sets the delete status of the data element.
         /// </summary>
         [JsonProperty(PropertyName = "deleteStatus")]
@@ -152,5 +158,23 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "dataElements")]
         public List<DataElement> DataElements { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a key-value pair.
+    /// </summary>
+    public class KeyValueEntry
+    {
+        /// <summary>
+        /// The key. Must be unique within the list.
+        /// </summary>
+        [JsonProperty(PropertyName = "key")]
+        public string Key { get; set; }
+        
+        /// <summary>
+        /// The value.
+        /// </summary>
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
     }
 }


### PR DESCRIPTION
DIBK has requested support for adding custom metadata to data elements.
https://github.com/Altinn/app-lib-dotnet/issues/392

## Description
They wanted something similar to "ekstraMetadata" here: https://developers.fiks.ks.no/tjenester/svarut/integrasjon/restv1/#dokumentmetadata

Considered using object for value, but they though string was good.
Should KeyValueEntry be in it's own file, or fine in the same file?

**There will be another PR with the required changes to set this property.**

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/392

## Verification
- [] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
