### PR TITLE
Fix `AbandonCurrentMoveToNext` authentication error for signature rejection

### DIFF
--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -84,7 +84,7 @@ namespace Altinn.Platform.Storage.Controllers
             string taskId = null;
 
             var moveNextFlows = new[] { "CompleteCurrentMoveToNext", "AbandonCurrentMoveToNext" };
-            if (processState?.CurrentTask?.FlowType != null && !moveNextFlows.Contains(processState.CurrentTask.FlowType))
+            if (processState?.CurrentTask?.FlowType is not null && !moveNextFlows.Contains(processState.CurrentTask.FlowType))
             {
                 altinnTaskType = processState.CurrentTask.AltinnTaskType;
                 taskId = processState.CurrentTask.ElementId;

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -83,7 +83,8 @@ namespace Altinn.Platform.Storage.Controllers
             string altinnTaskType = existingInstance.Process?.CurrentTask?.AltinnTaskType;
             string taskId = null;
 
-            if (processState?.CurrentTask?.FlowType != null && !processState.CurrentTask.FlowType.Equals("CompleteCurrentMoveToNext"))
+            var moveNextFlows = new[] { "CompleteCurrentMoveToNext", "AbandonCurrentMoveToNext" };
+            if (processState?.CurrentTask?.FlowType != null && !moveNextFlows.Contains(processState.CurrentTask.FlowType))
             {
                 altinnTaskType = processState.CurrentTask.AltinnTaskType;
                 taskId = processState.CurrentTask.ElementId;


### PR DESCRIPTION
## Description
Starting with [Altinn.App.Core v8.2.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.2.0), the reject action in a signature step produces a `FlowType=AbandonCurrentMoveToNext` instead of `FlowType=CompleteCurrentMoveToNext`.

This in turn has led to a 403 Forbidden error from the storage service due to incorrect permissions ([see issue](https://github.com/Altinn/app-lib-dotnet/issues/660)).

The code change in this PR fixes the issue _in this very specific case_, but I am uncertain of other potential side-effects of this change. The [ProcessControllerTest](https://github.com/Altinn/altinn-storage/blob/29d3b42586160dbb7e7da2ff817155205de5272f/test/UnitTest/TestingControllers/ProcessControllerTest.cs) runs green, but it's unclear to me if this covers all necessary scenarios. 

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/660

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
