### PR TITLE
Add CustomMetadata to DataElement.

### DIFF
--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -94,13 +94,19 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "tags")]
         public List<string> Tags { get; set; } = new List<string>();
+        
+        /// <summary>
+        /// Used to store user-defined custom metadata. This field is changeable by the end user, just like tags, and is not suitable to store system-controlled metadata.
+        /// </summary>
+        [JsonProperty(PropertyName = "customMetadata")]
+        public List<KeyValueEntry> CustomMetadata { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of key-value pairs that can be used to store metadata. Can be used in custom app code to store custom metadata.
+        /// Used to store application defined metadata about the data element. Meant to be used in custom backend code. This field should not be changeable by the end user.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]
         public List<KeyValueEntry> Metadata { get; set; }
-
+        
         /// <summary>
         /// Gets or sets the delete status of the data element.
         /// </summary>

--- a/src/Storage.Interface/Models/DataElement.cs
+++ b/src/Storage.Interface/Models/DataElement.cs
@@ -96,14 +96,20 @@ namespace Altinn.Platform.Storage.Interface.Models
         public List<string> Tags { get; set; } = new List<string>();
         
         /// <summary>
-        /// Used to store user-defined custom metadata. This field is changeable by the end user, just like tags, and is not suitable to store system-controlled metadata.
+        /// Gets or sets user-defined metadata associated with the data element.
         /// </summary>
-        [JsonProperty(PropertyName = "customMetadata")]
-        public List<KeyValueEntry> CustomMetadata { get; set; }
+        /// <remarks>
+        /// Changeable by the end user, like tags, and is not suitable to store system-controlled metadata.
+        /// </remarks>
+        [JsonProperty(PropertyName = "userDefinedMetadata")]
+        public List<KeyValueEntry> UserDefinedMetadata { get; set; }
 
         /// <summary>
-        /// Used to store application defined metadata about the data element. Meant to be used in custom backend code. This field should not be changeable by the end user.
+        /// Gets or sets application-defined metadata associated with the data element.
         /// </summary>
+        /// <remarks>
+        ///  Meant to be used in custom backend code. This field should not be changeable by the end user.
+        /// </remarks>
         [JsonProperty(PropertyName = "metadata")]
         public List<KeyValueEntry> Metadata { get; set; }
         


### PR DESCRIPTION
After discussing with internally and with DIBK we have decided that it would be useful to have two different metadata properties on data element.

1. One that is controlled by the end user, for custom metadata sent in through an endpoint in the altinn app.
2. One that is controlled by the application developer, and that can not be changed by the end user. Set through custom backend code.

I could do fine with just the first one for now, but the naming of the "Metadata" property that is currently merged into main in Storage.Interface matches best with the second variant, and I probably can't rename that property to match the first variant better now that it's out in main? @acn-sbuad 

**Very open to better name suggestions.**

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/392