### PR TITLE
Configure which keys are allowed for user defined metadata

### DIFF
--- a/src/Storage.Interface/Models/DataType.cs
+++ b/src/Storage.Interface/Models/DataType.cs
@@ -119,5 +119,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "enabledFileValidators")]
         public List<string> EnabledFileValidators { get; set; } = new List<string>();
+        
+        /// <summary>
+        /// Gets or sets a list of allowed keys for user defined metadata.
+        /// If null or empty, all user defined metadata keys are allowed.
+        /// </summary>
+        [JsonProperty(PropertyName = "allowedKeysForUserDefinedMetadata")]
+        public List<string> AllowedKeysForUserDefinedMetadata { get; set; }
     }
 }


### PR DESCRIPTION
Make it possible to configure which keys are allowed for user defined metadata on a certain data type.
DIBK wants to be able to limit what keys that are possible to set for user defined metadata.