### PR TITLE
Preserve the creation information when updating an existing app

### DIFF
--- a/src/Storage/Repository/PgApplicationRepository.cs
+++ b/src/Storage/Repository/PgApplicationRepository.cs
@@ -21,10 +21,11 @@ namespace Altinn.Platform.Storage.Repository
         private static readonly string _readSql = "select application from storage.applications";
         private static readonly string _readByOrgSql = "select application from storage.applications where org = $1";
         private static readonly string _readByIdSql = "select application from storage.applications where app = $1 and org = $2";
-        private static readonly string _deleteSql = "delete from storage.applications where app = $1 and org = $2";
+        private static readonly string _deleteSql = "delete from storage.applications where app = $1 and org = $2";   
         private static readonly string _updateSql = "update storage.applications set application = $3 where app = $1 and org = $2";
         private static readonly string _createSql = "insert into storage.applications (app, org, application) values ($1, $2, jsonb_strip_nulls($3))" +
-            " on conflict on constraint app_org do update set application = jsonb_strip_nulls($3)";
+            " on conflict on constraint app_org do update set application = jsonb_strip_nulls($3) ||" +
+            " jsonb_build_object($4, storage.applications.application->>$4) || jsonb_build_object($5, storage.applications.application->>$5)";
 
         private readonly IMemoryCache _memoryCache;
         private readonly MemoryCacheEntryOptions _cacheEntryOptionsTitles;
@@ -127,6 +128,8 @@ namespace Altinn.Platform.Storage.Repository
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, GetAppFromAppId(item.Id));
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, item.Org);
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Jsonb, item);
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, nameof(item.Created));
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, nameof(item.CreatedBy));
 
             await pgcom.ExecuteNonQueryAsync();
 

--- a/src/Storage/Repository/PgApplicationRepository.cs
+++ b/src/Storage/Repository/PgApplicationRepository.cs
@@ -21,8 +21,10 @@ namespace Altinn.Platform.Storage.Repository
         private static readonly string _readSql = "select application from storage.applications";
         private static readonly string _readByOrgSql = "select application from storage.applications where org = $1";
         private static readonly string _readByIdSql = "select application from storage.applications where app = $1 and org = $2";
-        private static readonly string _deleteSql = "delete from storage.applications where app = $1 and org = $2";   
-        private static readonly string _updateSql = "update storage.applications set application = $3 where app = $1 and org = $2";
+        private static readonly string _deleteSql = "delete from storage.applications where app = $1 and org = $2";
+        private static readonly string _updateSql = "update storage.applications set application = $3 ||" +
+            " jsonb_build_object($4, storage.applications.application->>$4) || jsonb_build_object($5, storage.applications.application->>$5) where app = $1 and org = $2";
+
         private static readonly string _createSql = "insert into storage.applications (app, org, application) values ($1, $2, jsonb_strip_nulls($3))" +
             " on conflict on constraint app_org do update set application = jsonb_strip_nulls($3) ||" +
             " jsonb_build_object($4, storage.applications.application->>$4) || jsonb_build_object($5, storage.applications.application->>$5)";
@@ -146,6 +148,8 @@ namespace Altinn.Platform.Storage.Repository
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, GetAppFromAppId(item.Id));
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, item.Org);
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Jsonb, item);
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, nameof(item.Created));
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, nameof(item.CreatedBy));
 
             await pgcom.ExecuteNonQueryAsync();
 

--- a/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -227,30 +227,28 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Arrange
             string org = "test";
             string appName = "app20";
-
             string getUri = $"{BasePath}/applications/{org}/{appName}";
             string postUri = $"{BasePath}/applications?appId={org}/{appName}";
 
             Application existingApp = CreateApplication(org, appName);
             existingApp.Created = DateTime.UtcNow.AddDays(-1);
             existingApp.CreatedBy = "testUser";
-            existingApp.PartyTypesAllowed = new PartyTypesAllowed { Person = true, SubUnit = true, Organisation = true, BankruptcyEstate = true };
+            existingApp.VersionId = "v1.0.0";
 
             Application newApp = CreateApplication(org, appName);
             newApp.Created = DateTime.UtcNow;
             newApp.CreatedBy = "anotherTestUser";
-            newApp.PartyTypesAllowed = new PartyTypesAllowed { Person = true, SubUnit = false, Organisation = false, BankruptcyEstate = true };
+            newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application
             {
-                Id = existingApp.Id,
-                Org = existingApp.Org,
+                Id = newApp.Id,
+                Org = newApp.Org,
+                VersionId = newApp.VersionId,
                 Created = existingApp.Created,
-                CreatedBy = existingApp.CreatedBy,
-                PartyTypesAllowed = newApp.PartyTypesAllowed
+                CreatedBy = existingApp.CreatedBy
             });
-
             applicationRepository.Setup(e => e.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -277,10 +275,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Assert.Equal(retrievedApp.Id, existingApp.Id);
             Assert.Equal(retrievedApp.Org, existingApp.Org);
+            Assert.Equal(retrievedApp.VersionId, newApp.VersionId);
             Assert.Equal(retrievedApp.Created, existingApp.Created);
             Assert.Equal(retrievedApp.CreatedBy, existingApp.CreatedBy);
-            Assert.Equal(retrievedApp.PartyTypesAllowed.SubUnit, newApp.PartyTypesAllowed.SubUnit);
-            Assert.Equal(retrievedApp.PartyTypesAllowed.Organisation, newApp.PartyTypesAllowed.Organisation);
         }
 
         /// <summary>

--- a/test/UnitTest/TestingRepositories/ApplicationTests.cs
+++ b/test/UnitTest/TestingRepositories/ApplicationTests.cs
@@ -58,7 +58,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
         {
             // Arrange
             Application a = await _applicationFixture.ApplicationRepo.Create(_a1);
-            a.CreatedBy = "updatedCreator";
+            _a1.VersionId = "v1";
 
             // Act
             await _applicationFixture.ApplicationRepo.Create(a);
@@ -68,7 +68,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             int count = await PostgresUtil.RunCountQuery(sql);
             Assert.Equal(1, count);
             Assert.Equal(_a1.Id, a.Id);
-            sql = $"select count(*) from storage.applications where app = '{App1}' and org = 'ttd' and application ->> 'CreatedBy' = 'updatedCreator'";
+
+            sql = $"select count(*) from storage.applications where app = '{App1}' and org = 'ttd' and application ->> 'VersionId' = 'v1'";
             count = await PostgresUtil.RunCountQuery(sql);
             Assert.Equal(1, count);
         }

--- a/test/UnitTest/TestingRepositories/ApplicationTests.cs
+++ b/test/UnitTest/TestingRepositories/ApplicationTests.cs
@@ -58,7 +58,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
         {
             // Arrange
             Application a = await _applicationFixture.ApplicationRepo.Create(_a1);
-            _a1.VersionId = "v1";
+            a.VersionId = "v1";
+            a.CreatedBy = "testUser";
+            a.Created = DateTime.Now.AddDays(-10);
 
             // Act
             await _applicationFixture.ApplicationRepo.Create(a);
@@ -72,6 +74,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingRepositories
             sql = $"select count(*) from storage.applications where app = '{App1}' and org = 'ttd' and application ->> 'VersionId' = 'v1'";
             count = await PostgresUtil.RunCountQuery(sql);
             Assert.Equal(1, count);
+
+            sql = $"select count(*) from storage.applications where app = '{App1}' and org = 'ttd' and application ->> 'VersionId' = '{a.VersionId}' and application ->> 'Created' = '{a.Created}' and application ->> 'CreatedBy' = '{a.CreatedBy}'";
+            count = await PostgresUtil.RunCountQuery(sql);
+            Assert.Equal(0, count);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Preserve both the CreatedBy and Create values when updating an existing application either by using a PUT or POST request.

## Related Issue(s)
- #361

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
