### PR TITLE
Use the appropriate data type based on the parameter name

### DIFF
--- a/src/Storage/Models/InstanceQueryParameters.cs
+++ b/src/Storage/Models/InstanceQueryParameters.cs
@@ -231,12 +231,13 @@ namespace Altinn.Platform.Storage.Models
             AddParamIfNotEmpty(postgresParams, _archiveReferenceParameterName, ArchiveReference?.ToLower());
             AddParamIfNotEmpty(postgresParams, _excludeConfirmedByParameterName, GetExcludeConfirmedBy(ExcludeConfirmedBy));
 
-            AddDateParamIfNotNull(postgresParams, _dueBeforeParameterName, DueBefore);
-            AddDateParamIfNotNull(postgresParams, _creationDateParameterName, Created);
-            AddDateParamIfNotNull(postgresParams, _lastChangedParameterName, LastChanged);
-            AddDateParamIfNotNull(postgresParams, _visibleAfterParameterName, VisibleAfter);
-            AddDateParamIfNotNull(postgresParams, _processEndedParameterName, ProcessEnded);
-            AddDateParamIfNotNull(postgresParams, _messageBoxIntervalParameterName, MsgBoxInterval);
+            AddDateParamIfNotNull(postgresParams, _creationDateParameterName, Created, false);
+            AddDateParamIfNotNull(postgresParams, _lastChangedParameterName, LastChanged, false);
+            AddDateParamIfNotNull(postgresParams, _messageBoxIntervalParameterName, MsgBoxInterval, false);
+
+            AddDateParamIfNotNull(postgresParams, _dueBeforeParameterName, DueBefore, true);
+            AddDateParamIfNotNull(postgresParams, _visibleAfterParameterName, VisibleAfter, true);
+            AddDateParamIfNotNull(postgresParams, _processEndedParameterName, ProcessEnded, true);
 
             if (!string.IsNullOrEmpty(SortBy))
             {
@@ -318,7 +319,8 @@ namespace Altinn.Platform.Storage.Models
         /// <param name="postgresParams">The dictionary to add the parameter to.</param>
         /// <param name="paramName">The name of the parameter.</param>
         /// <param name="queryValues">The query values containing the date.</param>
-        private static void AddDateParamIfNotNull(Dictionary<string, object> postgresParams, string paramName, StringValues queryValues)
+        /// <param name="useStringValue">Indicates whether to use the date value as a string.</param>
+        private static void AddDateParamIfNotNull(Dictionary<string, object> postgresParams, string paramName, StringValues queryValues, bool useStringValue)
         {
             if (StringValues.IsNullOrEmpty(queryValues))
             {
@@ -332,7 +334,7 @@ namespace Altinn.Platform.Storage.Models
                     string @operator = value.Split(':')[0];
                     string dateValue = value[(@operator.Length + 1)..];
                     string postgresParamName = GetPgParamName($"{paramName}_{@operator}");
-                    postgresParams.Add(postgresParamName, DateTimeHelper.ParseAndConvertToUniversalTime(dateValue));
+                    postgresParams.Add(postgresParamName, useStringValue ? dateValue : DateTimeHelper.ParseAndConvertToUniversalTime(dateValue));
                 }
                 catch
                 {


### PR DESCRIPTION
## Description
The procedure used to retrieve data from the data source expects different data types for certain DateTime input parameters. 

The system should provide **string** values for the following input parameters:
- `dueBefore`
- `visibleAfter`
- `process.ended`

and it should provide **DateTime** values for the following input parameters:
- `created`
- `lastChanged`
- `msgBoxInterval`


## Related Issue(s)
- #503 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
