### PR TITLE
Instance.Process.Validated is no longer in use by apps

### DIFF
--- a/src/Storage.Interface/Models/ProcessElementInfo.cs
+++ b/src/Storage.Interface/Models/ProcessElementInfo.cs
@@ -50,6 +50,7 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// Gets or sets the validation status.
         /// </summary>
         [JsonProperty(PropertyName = "validated")]
+        [Obsolete("ValidationStatus is no longer used by apps. Validation is performed on process changes instead")]
         public ValidationStatus Validated { get; set; }
 
         /// <summary>

--- a/src/Storage.Interface/Models/ValidationStatus.cs
+++ b/src/Storage.Interface/Models/ValidationStatus.cs
@@ -8,6 +8,7 @@ namespace Altinn.Platform.Storage.Interface.Models
     /// Represents the validation status of a data element.
     /// </summary>
     [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+    [Obsolete("ValidationStatus is no longer used by apps. Validation is performed on process changes instead")]
     public class ValidationStatus
     {
         /// <summary>


### PR DESCRIPTION
Apps from v8 and forward does not update or read instance.Process.Validated, but rather run validation as part of the call to process/next

It should likely not be used by other systems either, so a deprecation is likely a good thing that will show up in openApi specifications.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
