### PR TITLE
Changed  a2 pdf generation to push html to the generator

### DIFF
--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -13,7 +13,7 @@
   
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.0.8" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.6.1" /> 
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.2" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.3" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />

--- a/src/Storage/Clients/IPdfGeneratorClient.cs
+++ b/src/Storage/Clients/IPdfGeneratorClient.cs
@@ -14,6 +14,6 @@ namespace Altinn.Platform.Storage.Clients
         /// Generates a PDF.
         /// </summary>
         /// <returns>A stream with the binary content of the generated PDF</returns>
-        Task<Stream> GeneratePdf(string url, bool isPortrait);
+        Task<Stream> GeneratePdf(string html, bool isPortrait);
     }
 }

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -294,7 +294,7 @@ namespace Altinn.Platform.Storage.Repository
                         previousId = id;
                     }
 
-                    if (!reader.IsDBNull("element"))
+                    if (!await reader.IsDBNullAsync("element"))
                     {
                         instance.Data.Add(await reader.GetFieldValueAsync<DataElement>("element"));
                     }
@@ -342,7 +342,7 @@ namespace Altinn.Platform.Storage.Repository
                         instanceInternalId = await reader.GetFieldValueAsync<long>("id");
                     }
 
-                    if (includeElements && !reader.IsDBNull("element"))
+                    if (includeElements && !await reader.IsDBNullAsync("element"))
                     {
                         instanceData.Add(await reader.GetFieldValueAsync<DataElement>("element"));
                     }

--- a/src/Storage/Services/A2OndemandFormattingService.cs
+++ b/src/Storage/Services/A2OndemandFormattingService.cs
@@ -37,9 +37,9 @@ namespace Altinn.Platform.Storage.Services
         }
 
         /// <inheritdoc/>
-        public Stream GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string archiveStamp)
+        public string GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string archiveStamp)
         {
-            return new MemoryStream(Encoding.UTF8.GetBytes(GetFormdataHtmlInternal(xmlData, printXslList, archiveStamp)));
+            return GetFormdataHtmlInternal(xmlData, printXslList, archiveStamp);
         }
 
         private string GetFormdataHtmlInternal(

--- a/src/Storage/Services/IA2OndemandFormattingService.cs
+++ b/src/Storage/Services/IA2OndemandFormattingService.cs
@@ -16,7 +16,7 @@ namespace Altinn.Platform.Storage.Services
         /// <param name="printXslList">printXslList</param>
         /// <param name="xmlData">xmlData</param>
         /// <param name="archiveStamp">Timestamp used for water mark</param>
-        /// <returns>Html as stream</returns>
-        Stream GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string archiveStamp);
+        /// <returns>Html as string</returns>
+        string GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string archiveStamp);
     }
 }


### PR DESCRIPTION
## Description
- Changed pdf generation to push html to the generator
- Avoid multiple convertions between string and stream when generating pdf
- Bumped storage.interface to 4.0.3

## Related Issue(s)
- #439

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
