### PR TITLE
Migrated a2 app watermark

### DIFF
--- a/src/Storage/Controllers/ContentOnDemandController.cs
+++ b/src/Storage/Controllers/ContentOnDemandController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -236,10 +237,12 @@ namespace Altinn.Platform.Storage.Controllers
 
             xsls[^1].LastPage = true;
 
+            string watermark = ((DateTime)xmlElement.Created).ToString("dd-MM-yyyy HH:mm:ss", CultureInfo.InvariantCulture)
+                + $" AR{instance.DataValues["A2ArchRef"]}";
             return _a2OndemandFormattingService.GetFormdataHtml(
                 xsls,
                 await _blobRepository.ReadBlob($"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}", $"{instance.Org}/{app}/{instanceGuid}/data/{xmlElement.Id}", application.StorageAccountNumber),
-                xmlElement.Created.ToString());
+                watermark);
         }
     }
 

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -206,6 +206,13 @@ namespace Altinn.Platform.Storage.Controllers
                     return NotFound($"Unable to read data element from blob storage for {dataGuid}");
                 }
 
+                // Migrated Altinn 2 Websa main forms should be shown inline in the browser
+                if (instance.AppId.Contains(@"/a2-") && dataElement.DataType == "ref-data-as-pdf" && dataElement.ContentType == "text/html")
+                {
+                    Response.Headers.Append(HeaderNames.ContentDisposition, "inline");
+                    return File(dataStream, dataElement.ContentType);
+                }
+
                 return File(dataStream, dataElement.ContentType, dataElement.Filename);
             }
             else if (dataElement.BlobStoragePath.StartsWith("ondemand"))

--- a/src/Storage/Services/A2OndemandFormattingService.cs
+++ b/src/Storage/Services/A2OndemandFormattingService.cs
@@ -45,7 +45,7 @@ namespace Altinn.Platform.Storage.Services
         private string GetFormdataHtmlInternal(
             Stream formData,
             PrintViewXslBEList printViewXslBEList,
-            string archiveStamp)
+            string watermark)
         {
             XmlDocument xmlDoc = new();
             xmlDoc.Load(formData);
@@ -86,7 +86,7 @@ namespace Altinn.Platform.Storage.Services
                 htmlToTranslate = htmlToTranslate.Replace("</head>", _css);
 
                 // Add the archive time stamp and the list of attachments
-                htmlToTranslate = SetArchiveTimeStampToHtml(archiveStamp, htmlToTranslate);
+                htmlToTranslate = SetArchiveTimeStampToHtml(watermark, htmlToTranslate);
 
                 htmlString.Append(htmlToTranslate);
             }

--- a/src/Storage/Services/IA2OndemandFormattingService.cs
+++ b/src/Storage/Services/IA2OndemandFormattingService.cs
@@ -15,8 +15,8 @@ namespace Altinn.Platform.Storage.Services
         /// </summary>
         /// <param name="printXslList">printXslList</param>
         /// <param name="xmlData">xmlData</param>
-        /// <param name="archiveStamp">Timestamp used for water mark</param>
+        /// <param name="watermark">Timestamp used for water mark</param>
         /// <returns>Html as string</returns>
-        string GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string archiveStamp);
+        string GetFormdataHtml(PrintViewXslBEList printXslList, Stream xmlData, string watermark);
     }
 }


### PR DESCRIPTION
## Description
- Migrated a2 app watermark: Date formatting and added reference number
- Make html inline in browser

## Related Issue(s)
- #439 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
