### PR TITLE
A2 migration: Use scale parameter in html->pdf generation

### DIFF
--- a/src/Storage/Clients/IPdfGeneratorClient.cs
+++ b/src/Storage/Clients/IPdfGeneratorClient.cs
@@ -14,6 +14,6 @@ namespace Altinn.Platform.Storage.Clients
         /// Generates a PDF.
         /// </summary>
         /// <returns>A stream with the binary content of the generated PDF</returns>
-        Task<Stream> GeneratePdf(string html, bool isPortrait);
+        Task<Stream> GeneratePdf(string html, bool isPortrait, float scale);
     }
 }

--- a/src/Storage/Clients/PdfGeneratorClient.cs
+++ b/src/Storage/Clients/PdfGeneratorClient.cs
@@ -40,12 +40,12 @@ public class PdfGeneratorClient: IPdfGeneratorClient
     }
 
     /// <inheritdoc/>
-    public async Task<Stream> GeneratePdf(string html, bool isPortrait)
+    public async Task<Stream> GeneratePdf(string html, bool isPortrait, float scale)
     {
         var request = new PdfGeneratorRequest
         {
             Html = html,
-            Options = new() { Landscape = !isPortrait }
+            Options = new() { Landscape = !isPortrait, Scale = scale }
         };
         string requestContent = JsonSerializer.Serialize(request, _jsonSerializerOptions);
         var httpResponseMessage = await _httpClient.PostAsync(_httpClient.BaseAddress, new StringContent(requestContent, Encoding.UTF8, "application/json"));
@@ -116,6 +116,11 @@ public class PdfGeneratorClient: IPdfGeneratorClient
         /// Defines the page margins. Default is "0.4in" on all sides.
         /// </summary>
         public MarginOptions Margin { get; set; } = new();
+
+        /// <summary>
+        /// Scales the rendering of the web page. Amount must be between 0.1 and 2
+        /// </summary>
+        public float Scale { get; set; } = 1;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
- Use scale parameter in pdf generation so that proper margins are applied

## Related Issue(s)
- #439 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
