### PR TITLE
Add list support to sync adapter

### DIFF
--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -36,11 +36,18 @@ namespace Altinn.Platform.Storage.Authorization
         public Task<List<Instance>> AuthorizeInstances(List<Instance> instances);
 
         /// <summary>
-        /// Verifies a scope claim based on claimsprincipal.
+        /// Verifies that the user has at least one of the supplied scopes.
         /// </summary>
-        /// <param name="requiredScope">Requiered scope.</param>
-        /// <returns>true if the given ClaimsPrincipal or on of its identities have contains the given scope.</returns>
+        /// <param name="requiredScope">Required scopes</param>
+        /// <returns>true if the current user have contains any of the scopes provided.</returns>
         public bool UserHasRequiredScope(List<string> requiredScope);
+
+        /// <summary>
+        /// Verifies that the user has the supplied scope.
+        /// </summary>
+        /// <param name="requiredScope">Required scopes</param>
+        /// <returns>true if the current user has the scope provided.</returns>
+        public bool UserHasRequiredScope(string requiredScope);
 
         /// <summary>
         /// Sends in a request and get response with result of the request

--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -39,7 +39,7 @@ namespace Altinn.Platform.Storage.Authorization
         /// Verifies that the user has at least one of the supplied scopes.
         /// </summary>
         /// <param name="requiredScope">Required scopes</param>
-        /// <returns>true if the current user have contains any of the scopes provided.</returns>
+        /// <returns>true if the current user has any of the scopes provided.</returns>
         public bool UserHasRequiredScope(List<string> requiredScope);
 
         /// <summary>

--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -106,7 +106,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (orgClaim != null)
             {
-                if (!_authorizationService.UserHasRequiredScope(_generalSettings.InstanceReadScope) && !hasSyncAdapterScope)
+                if (!hasSyncAdapterScope && !_authorizationService.UserHasRequiredScope(_generalSettings.InstanceReadScope))
                 {
                     return Forbid();
                 }
@@ -121,7 +121,7 @@ namespace Altinn.Platform.Storage.Controllers
                     queryParameters.Org = queryParameters.AppId.Split('/')[0];
                 }
                 
-                if (!orgClaim.Equals(queryParameters.Org, StringComparison.InvariantCultureIgnoreCase) && !hasSyncAdapterScope)
+                if (!hasSyncAdapterScope && !orgClaim.Equals(queryParameters.Org, StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (string.IsNullOrEmpty(queryParameters.AppId))
                     {
@@ -202,7 +202,7 @@ namespace Altinn.Platform.Storage.Controllers
                 queryParameters.ContinuationToken = HttpUtility.UrlDecode(queryParameters.ContinuationToken);
             }
 
-            bool appOwnerOrSyncAdapterRequestingInstances = User.HasServiceOwnerScope() || hasSyncAdapterScope;
+            bool appOwnerOrSyncAdapterRequestingInstances = hasSyncAdapterScope || User.HasServiceOwnerScope();
 
             // filter out hard deleted instances if it isn't the appOwner or the sync adapter requesting instances 
             if (!appOwnerOrSyncAdapterRequestingInstances)

--- a/test/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -899,24 +899,53 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
     }
 
     /// <summary>
-    /// Test case: Get Multiple instances using client with sync adapter scope should faile.
+    /// Test case: Get Multiple instances using client with sync adapter scope should work.
     /// Expected: Returns status forbidden.
     /// </summary>
     [Fact]
-    public async Task GetMany_SyncAdapterScope_ReturnsForbidden()
+    public async Task GetMany_SyncAdapterScope_OK()
     {
         // Arrange
-        string requestUri = $"{BasePath}?org=testOrg";
+        string requestUri = $"{BasePath}?org=ttd";
 
+        var expectedNoInstances = 13;
+        
         HttpClient client = GetTestClient();
         string token = PrincipalUtil.GetOrgToken("testOrg", scope: "altinn:storage/instances.syncadapter");
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         // Act
         HttpResponseMessage response = await client.GetAsync(requestUri);
+        string json = await response.Content.ReadAsStringAsync();
+        InstanceQueryResponse queryResponse = JsonConvert.DeserializeObject<InstanceQueryResponse>(json);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expectedNoInstances, queryResponse.Count);
+    }
+    
+    /// <summary>
+    /// Scenario:
+    ///   The sync adapter calls the API via apps-endpoints authenticated digdir, which is not the app's service owner.
+    ///   This should be allowed regardless of policy.
+    /// Result:
+    ///   Returns status is OK.
+    /// </summary>
+    [Fact]
+    public async Task GetMany_QueryingDifferentOrgThanInClaims_ReturnsOKIfSyncAdapter()
+    {
+        // Arrange
+        string requestUri = $"{BasePath}?instanceOwner.PartyId=1337&appId=sfvt/test-read-app-no-permission";
+
+        HttpClient client = GetTestClient();
+        string token = PrincipalUtil.GetOrgToken("digdir", scope: "altinn:storage/instances.syncadapter");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
This adds support for querying for instances for the sync adapter, which was previously intentionally omitted.

List operations will not be used during normal sync operations, but is required for targeted migration of already existing/archived instances.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
