### PR TITLE
Remove the cache step from build workflow

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -56,12 +56,6 @@ jobs:
       - name: Restart database to enable config changes
         run: |
           docker restart $(docker ps -q)
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Install SonarCloud scanners
         run: |
           dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
Removes superfluous caching step of Sonar packages in the build pipeline. Further description can be found in the linked issue.

## Related Issue(s)
[#153](https://github.com/Altinn/team-core-private/issues/153) (team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
