### PR TITLE
Delete existing signature

### DIFF
--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -177,7 +177,7 @@ namespace Altinn.Platform.Storage.Controllers
                 return instanceError;
             }
 
-            Application app = await _applicationRepository.FindOne(instance.AppId, instance.Org);
+            Application app = await _applicationRepository.FindOne(instance.AppId, instance.Org, cancellationToken);
 
             (DataElement dataElement, ActionResult dataElementError) = await GetDataElementAsync(instanceGuid, dataGuid);
             if (dataElement == null)
@@ -206,7 +206,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (string.Equals(dataElement.BlobStoragePath, storageFileName))
             {
-                Stream dataStream = await _blobRepository.ReadBlob(instance.Org, storageFileName, app.StorageAccountNumber);
+                Stream dataStream = await _blobRepository.ReadBlob(instance.Org, storageFileName, app.StorageAccountNumber, cancellationToken);
 
                 if (dataStream == null)
                 {

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -144,7 +144,9 @@ namespace Altinn.Platform.Storage.Controllers
             }
 
             dataElement.LastChangedBy = userOrOrgNo;
-            return await DeleteImmediately(instance, dataElement, application.StorageAccountNumber);
+            await _dataService.DeleteImmediately(instance, dataElement, application.StorageAccountNumber);
+            
+            return Ok(dataElement);
         }
 
         /// <summary>
@@ -616,19 +618,6 @@ namespace Altinn.Platform.Storage.Controllers
 
             await _instanceEventService.DispatchEvent(InstanceEventType.Deleted, instance, dataElement);
             return Ok(updatedDateElement);
-        }
-
-        private async Task<ActionResult<DataElement>> DeleteImmediately(Instance instance, DataElement dataElement, int? storageAccountNumber)
-        {
-            string storageFileName = DataElementHelper.DataFileName(instance.AppId, dataElement.InstanceGuid, dataElement.Id);
-
-            await _blobRepository.DeleteBlob(instance.Org, storageFileName, storageAccountNumber);
-
-            await _dataRepository.Delete(dataElement);
-
-            await _instanceEventService.DispatchEvent(InstanceEventType.Deleted, instance, dataElement);
-
-            return Ok(dataElement);
         }
     }
 }

--- a/src/Storage/Controllers/SignController.cs
+++ b/src/Storage/Controllers/SignController.cs
@@ -23,7 +23,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <summary>
         /// Initializes a new instance of the <see cref="SignController"/> class
         /// </summary>
-        /// <param name="signingService">A instance service with instance related business logic.</param>
+        /// <param name="signingService">An instance service with instance related business logic.</param>
         public SignController(ISigningService signingService)
         {
             _signingService = signingService;
@@ -34,7 +34,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// </summary>
         /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
         /// <param name="instanceGuid">The guid of the instance.</param>
-        /// <param name="signRequest">Signrequest containing data element ids and sign status.</param>
+        /// <param name="signRequest">Sign request containing data element ids and sign status.</param>
         /// <param name="cancellationToken">CancellationToken</param>
         [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_SIGN)]
         [HttpPost("{instanceOwnerPartyId:int}/{instanceGuid:guid}/sign")]

--- a/src/Storage/Controllers/SignController.cs
+++ b/src/Storage/Controllers/SignController.cs
@@ -18,15 +18,15 @@ namespace Altinn.Platform.Storage.Controllers
     [ApiController]
     public class SignController : ControllerBase
     {
-        private readonly IInstanceService _instanceService;
+        private readonly ISigningService _signingService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SignController"/> class
         /// </summary>
-        /// <param name="instanceService">A instance service with instance related business logic.</param>
-        public SignController(IInstanceService instanceService)
+        /// <param name="signingService">A instance service with instance related business logic.</param>
+        public SignController(ISigningService signingService)
         {
-            _instanceService = instanceService;
+            _signingService = signingService;
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Altinn.Platform.Storage.Controllers
                 return Unauthorized();
             }
 
-            (bool created, ServiceError serviceError) = await _instanceService.CreateSignDocument(instanceOwnerPartyId, instanceGuid, signRequest, performedBy, cancellationToken);
+            (bool created, ServiceError serviceError) = await _signingService.CreateSignDocument(instanceOwnerPartyId, instanceGuid, signRequest, performedBy, cancellationToken);
             
             if (created)
             {

--- a/src/Storage/Controllers/SignController.cs
+++ b/src/Storage/Controllers/SignController.cs
@@ -55,7 +55,7 @@ namespace Altinn.Platform.Storage.Controllers
                 return Unauthorized();
             }
 
-            (bool created, ServiceError serviceError) = await _signingService.CreateSignDocument(instanceOwnerPartyId, instanceGuid, signRequest, performedBy, cancellationToken);
+            (bool created, ServiceError serviceError) = await _signingService.CreateSignDocument(instanceGuid, signRequest, performedBy, cancellationToken);
             
             if (created)
             {

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -292,7 +292,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddSingleton<IAccessTokenGenerator, AccessTokenGenerator>();
     services.AddSingleton<ISigningCredentialsResolver, SigningCredentialsResolver>();
     services.AddTransient<IDataService, DataService>();
-    services.AddTransient<IInstanceService, InstanceService>();
+    services.AddTransient<ISigningService, SigningService>();
     services.AddTransient<IInstanceEventService, InstanceEventService>();
     services.AddSingleton<IApplicationService, ApplicationService>();
     services.AddSingleton<IA2OndemandFormattingService, A2OndemandFormattingService>();

--- a/src/Storage/Repository/BlobRepository.cs
+++ b/src/Storage/Repository/BlobRepository.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Storage.Repository
             .SetAbsoluteExpiration(new TimeSpan(10, 0, 0));
 
         /// <inheritdoc/>
-        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null)
+        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/Storage/Repository/BlobRepository.cs
+++ b/src/Storage/Repository/BlobRepository.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Storage.Repository
             .SetAbsoluteExpiration(new TimeSpan(10, 0, 0));
 
         /// <inheritdoc/>
-        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken)
+        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null)
         {
             try
             {

--- a/src/Storage/Repository/BlobRepository.cs
+++ b/src/Storage/Repository/BlobRepository.cs
@@ -170,11 +170,11 @@ namespace Altinn.Platform.Storage.Repository
             return properties;
         }
 
-        private async Task<Stream> DownloadBlobAsync(string org, string fileName, int? storageAccountNumber, CancellationToken? cancellationToken = null)
+        private async Task<Stream> DownloadBlobAsync(string org, string fileName, int? storageAccountNumber, CancellationToken cancellationToken = default)
         {
             BlobClient blockBlob = CreateBlobClient(org, fileName, storageAccountNumber);
 
-            Azure.Response<BlobDownloadInfo> response = await blockBlob.DownloadAsync(cancellationToken ?? CancellationToken.None);
+            Azure.Response<BlobDownloadInfo> response = await blockBlob.DownloadAsync(cancellationToken);
 
             return response.Value.Content;
         }

--- a/src/Storage/Repository/BlobRepository.cs
+++ b/src/Storage/Repository/BlobRepository.cs
@@ -44,11 +44,11 @@ namespace Altinn.Platform.Storage.Repository
             .SetAbsoluteExpiration(new TimeSpan(10, 0, 0));
 
         /// <inheritdoc/>
-        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber)
+        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken)
         {
             try
             {
-                return await DownloadBlobAsync(org, blobStoragePath, storageAccountNumber);
+                return await DownloadBlobAsync(org, blobStoragePath, storageAccountNumber, cancellationToken);
             }
             catch (RequestFailedException requestFailedException)
             {
@@ -170,11 +170,11 @@ namespace Altinn.Platform.Storage.Repository
             return properties;
         }
 
-        private async Task<Stream> DownloadBlobAsync(string org, string fileName, int? storageAccountNumber)
+        private async Task<Stream> DownloadBlobAsync(string org, string fileName, int? storageAccountNumber, CancellationToken? cancellationToken = null)
         {
             BlobClient blockBlob = CreateBlobClient(org, fileName, storageAccountNumber);
 
-            Azure.Response<BlobDownloadInfo> response = await blockBlob.DownloadAsync();
+            Azure.Response<BlobDownloadInfo> response = await blockBlob.DownloadAsync(cancellationToken ?? CancellationToken.None);
 
             return response.Value.Content;
         }

--- a/src/Storage/Repository/IApplicationRepository.cs
+++ b/src/Storage/Repository/IApplicationRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Interface.Models;
@@ -27,9 +28,10 @@ namespace Altinn.Platform.Storage.Repository
         /// Get the instance based on the input parameters
         /// </summary>
         /// <param name="appId">application id</param>
-        /// <param name="org">applicaiton owner id</param>
+        /// <param name="org">application owner id</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the instance for the given parameters</returns>
-        Task<Application> FindOne(string appId, string org);
+        Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Creates an application metadata object in repository

--- a/src/Storage/Repository/IApplicationRepository.cs
+++ b/src/Storage/Repository/IApplicationRepository.cs
@@ -31,7 +31,7 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="org">application owner id</param>
         /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the instance for the given parameters</returns>
-        Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null);
+        Task<Application> FindOne(string appId, string org, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates an application metadata object in repository

--- a/src/Storage/Repository/IBlobRepository.cs
+++ b/src/Storage/Repository/IBlobRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -26,8 +27,9 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="org">The application owner id.</param>
         /// <param name="blobStoragePath">Path to be file to read blob storage.</param>
         /// <param name="storageAccountNumber">Storage container number for when a Storage account has more than one container.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The stream with the file</returns>
-        Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber);
+        Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Deletes the blob element permanently

--- a/src/Storage/Repository/IBlobRepository.cs
+++ b/src/Storage/Repository/IBlobRepository.cs
@@ -29,7 +29,7 @@ namespace Altinn.Platform.Storage.Repository
         /// <param name="storageAccountNumber">Storage container number for when a Storage account has more than one container.</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The stream with the file</returns>
-        Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null);
+        Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes the blob element permanently

--- a/src/Storage/Repository/PgApplicationRepository.cs
+++ b/src/Storage/Repository/PgApplicationRepository.cs
@@ -88,7 +88,7 @@ namespace Altinn.Platform.Storage.Repository
         }
 
         /// <inheritdoc/>
-        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken)
+        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null)
         {
             string cacheKey = $"aid:{appId}";
             if (!_memoryCache.TryGetValue(cacheKey, out Application application))

--- a/src/Storage/Repository/PgApplicationRepository.cs
+++ b/src/Storage/Repository/PgApplicationRepository.cs
@@ -88,7 +88,7 @@ namespace Altinn.Platform.Storage.Repository
         }
 
         /// <inheritdoc/>
-        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null)
+        public async Task<Application> FindOne(string appId, string org, CancellationToken cancellationToken = default)
         {
             string cacheKey = $"aid:{appId}";
             if (!_memoryCache.TryGetValue(cacheKey, out Application application))
@@ -96,10 +96,10 @@ namespace Altinn.Platform.Storage.Repository
                 await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_readByIdSql);
                 pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, GetAppFromAppId(appId));
                 pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, org);
-                await using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync(cancellationToken ?? CancellationToken.None);
-                if (await reader.ReadAsync(cancellationToken ?? CancellationToken.None))
+                await using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync(cancellationToken);
+                if (await reader.ReadAsync(cancellationToken))
                 {
-                    application = await reader.GetFieldValueAsync<Application>("application", cancellationToken ?? CancellationToken.None);
+                    application = await reader.GetFieldValueAsync<Application>("application", cancellationToken);
                     _memoryCache.Set(cacheKey, application, _cacheEntryOptionsMetadata);
                 }
                 else

--- a/src/Storage/Repository/PgApplicationRepository.cs
+++ b/src/Storage/Repository/PgApplicationRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Interface.Models;
@@ -87,7 +88,7 @@ namespace Altinn.Platform.Storage.Repository
         }
 
         /// <inheritdoc/>
-        public async Task<Application> FindOne(string appId, string org)
+        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken)
         {
             string cacheKey = $"aid:{appId}";
             if (!_memoryCache.TryGetValue(cacheKey, out Application application))
@@ -95,10 +96,10 @@ namespace Altinn.Platform.Storage.Repository
                 await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_readByIdSql);
                 pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, GetAppFromAppId(appId));
                 pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, org);
-                await using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
-                if (await reader.ReadAsync())
+                await using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync(cancellationToken ?? CancellationToken.None);
+                if (await reader.ReadAsync(cancellationToken ?? CancellationToken.None))
                 {
-                    application = await reader.GetFieldValueAsync<Application>("application");
+                    application = await reader.GetFieldValueAsync<Application>("application", cancellationToken ?? CancellationToken.None);
                     _memoryCache.Set(cacheKey, application, _cacheEntryOptionsMetadata);
                 }
                 else

--- a/src/Storage/Services/IDataService.cs
+++ b/src/Storage/Services/IDataService.cs
@@ -45,5 +45,14 @@ namespace Altinn.Platform.Storage.Services
         /// <param name="instanceInternalId">The internal id of the data element to insert.</param>
         /// <param name="storageAccountNumber">Storage container number for when a Storage account has more than one container.</param>
         Task UploadDataAndCreateDataElement(string org, Stream stream, DataElement dataElement, long instanceInternalId, int? storageAccountNumber);
+
+        /// <summary>
+        /// Delete a data element and it's blob data immediately.
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <param name="dataElement">The data element</param>
+        /// <param name="storageAccountNumber">Storage container number for when a Storage account has more than one container.</param>
+        /// <returns></returns>
+        Task<DataElement> DeleteImmediately(Instance instance, DataElement dataElement, int? storageAccountNumber);
     }
 }

--- a/src/Storage/Services/ISigningService.cs
+++ b/src/Storage/Services/ISigningService.cs
@@ -7,9 +7,9 @@ using Altinn.Platform.Storage.Models;
 namespace Altinn.Platform.Storage.Services
 {
     /// <summary>
-    /// This interface describes the required methods and features of a instance service implementation.
+    /// This interface describes the required methods and features of a signing service implementation.
     /// </summary>
-    public interface IInstanceService
+    public interface ISigningService
     {
         /// <summary>
         /// Create signature document for given dataelements, this includes creating md5 hash for all blobs listed.

--- a/src/Storage/Services/ISigningService.cs
+++ b/src/Storage/Services/ISigningService.cs
@@ -12,14 +12,12 @@ namespace Altinn.Platform.Storage.Services
     public interface ISigningService
     {
         /// <summary>
-        /// Create signature document for given dataelements, this includes creating md5 hash for all blobs listed.
+        /// Create signature document for given data elements, this includes creating md5 hash for all blobs listed.
         /// </summary>
-        /// <param name="instanceOwnerPartyId">The instance owner partyId</param>
         /// <param name="instanceGuid">The instance guid</param>
-        /// <param name="signRequest">Signrequest containing data element ids and sign status</param>
+        /// <param name="signRequest">Sign request containing data element ids and sign status</param>
         /// <param name="performedBy">User id or org no for the authenticated user</param>
         /// <param name="cancellationToken">CancellationToken</param>
-        Task<(bool Created, ServiceError ServiceError)> CreateSignDocument(
-            int instanceOwnerPartyId, Guid instanceGuid, SignRequest signRequest, string performedBy, CancellationToken cancellationToken); 
+        Task<(bool Created, ServiceError ServiceError)> CreateSignDocument(Guid instanceGuid, SignRequest signRequest, string performedBy, CancellationToken cancellationToken); 
     }
 }

--- a/src/Storage/Services/SigningService.cs
+++ b/src/Storage/Services/SigningService.cs
@@ -148,7 +148,7 @@ namespace Altinn.Platform.Storage.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error deleting existing sign document for Instance {InstanceId}", instance.Id);
+                _logger.LogError("Error deleting existing sign document for Instance {InstanceId}", instance.Id);
                 throw;
             }
         }
@@ -179,8 +179,8 @@ namespace Altinn.Platform.Storage.Services
                 signee1.OrganisationNumber == signee2.OrganisationNumber;
     }
     
-    #pragma warning disable SA1600 Elements should be documented
-    file record SignDocDownloadResult
+    #pragma warning disable SA1600 // Elements should be documented
+    file sealed record SignDocDownloadResult
     {
         public DataElement DataElement { get; init; }
         

--- a/src/Storage/Services/SigningService.cs
+++ b/src/Storage/Services/SigningService.cs
@@ -148,7 +148,7 @@ namespace Altinn.Platform.Storage.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError("Error deleting existing sign document for Instance {InstanceId}", instance.Id);
+                _logger.LogError(ex, "Error deleting existing sign document for Instance {InstanceId}", instance.Id);
                 throw;
             }
         }

--- a/test/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Interface.Models;
@@ -22,7 +23,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             throw new NotImplementedException();
         }
 
-        public async Task<Application> FindOne(string appId, string org)
+        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null)
         {
             return await Task.FromResult(GetTestApplication(org, appId.Split("/")[1]));
         }

--- a/test/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/ApplicationRepositoryMock.cs
@@ -23,7 +23,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             throw new NotImplementedException();
         }
 
-        public async Task<Application> FindOne(string appId, string org, CancellationToken? cancellationToken = null)
+        public async Task<Application> FindOne(string appId, string org, CancellationToken cancellationToken = default)
         {
             return await Task.FromResult(GetTestApplication(org, appId.Split("/")[1]));
         }

--- a/test/UnitTest/Mocks/Repository/BlobRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/BlobRepositoryMock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Interface.Models;
@@ -14,7 +15,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return await Task.FromResult(true);
         }
 
-        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber)
+        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null)
         {
             string dataPath = Path.Combine(GetDataBlobPath(), blobStoragePath);
             Stream fs = File.OpenRead(dataPath);

--- a/test/UnitTest/Mocks/Repository/BlobRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/BlobRepositoryMock.cs
@@ -15,7 +15,7 @@ namespace Altinn.Platform.Storage.UnitTest.Mocks.Repository
             return await Task.FromResult(true);
         }
 
-        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken? cancellationToken = null)
+        public async Task<Stream> ReadBlob(string org, string blobStoragePath, int? storageAccountNumber, CancellationToken cancellationToken = default)
         {
             string dataPath = Path.Combine(GetDataBlobPath(), blobStoragePath);
             Stream fs = File.OpenRead(dataPath);

--- a/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Common.AccessToken.Services;
@@ -90,7 +91,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Application)null);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((Application)null);
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -128,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -161,7 +162,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -243,7 +244,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -312,7 +313,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -362,7 +363,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -396,7 +397,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -432,7 +433,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -467,7 +468,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -508,7 +509,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -543,7 +544,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -644,7 +645,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>()))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None))
               .ReturnsAsync((Application)null);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -654,7 +655,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None), Times.Once);
         }
 
         /// <summary>
@@ -668,7 +669,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>()))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(),CancellationToken.None))
               .ReturnsAsync(new Application { Id = "ttd/existing-app" });
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -678,7 +679,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None), Times.Once);
         }
 
         private HttpClient GetTestClient(IApplicationRepository applicationRepository)

--- a/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -91,7 +91,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync((Application)null);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((Application)null);
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -129,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -162,7 +162,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -244,7 +244,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -313,7 +313,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -363,7 +363,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -397,7 +397,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -433,7 +433,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -468,7 +468,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -509,7 +509,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -544,7 +544,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -645,7 +645,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
               .ReturnsAsync((Application)null);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -655,7 +655,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         /// <summary>
@@ -669,7 +669,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
               .ReturnsAsync(new Application { Id = "ttd/existing-app" });
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -679,7 +679,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private HttpClient GetTestClient(IApplicationRepository applicationRepository)

--- a/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ApplicationsControllerTests.cs
@@ -91,7 +91,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((Application)null);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync((Application)null);
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -129,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -162,7 +162,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ThrowsAsync(new Exception());
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ThrowsAsync(new Exception());
             applicationRepository.Setup(s => s.Create(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -244,7 +244,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -313,7 +313,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             newApp.VersionId = "v1.0.1";
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(new Application
+            applicationRepository.Setup(e => e.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application
             {
                 Id = newApp.Id,
                 Org = newApp.Org,
@@ -363,7 +363,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -397,7 +397,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -433,7 +433,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application appInfo = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(appInfo);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(appInfo);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -468,7 +468,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -509,7 +509,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -544,7 +544,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Application originalApp = CreateApplication(org, appName);
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
-            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(originalApp);
+            applicationRepository.Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(originalApp);
             applicationRepository.Setup(s => s.Update(It.IsAny<Application>())).ReturnsAsync((Application app) => app);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -645,7 +645,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
               .ReturnsAsync((Application)null);
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -655,7 +655,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         /// <summary>
@@ -669,7 +669,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<IApplicationRepository> applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository
-              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(),CancellationToken.None))
+              .Setup(s => s.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
               .ReturnsAsync(new Application { Id = "ttd/existing-app" });
 
             HttpClient client = GetTestClient(applicationRepository.Object);
@@ -679,7 +679,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None), Times.Once);
+            applicationRepository.Verify(m => m.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         private HttpClient GetTestClient(IApplicationRepository applicationRepository)

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -172,7 +172,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             blobRepositoryMock
-                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), CancellationToken.None))
+                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
                 .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("whatever")));
 
             blobRepositoryMock
@@ -197,7 +197,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             applicationRepositoryMock
-                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None))
+                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
                 .ReturnsAsync(new Application()
                 {
                     DataTypes = new List<DataType>()

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -172,7 +172,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             blobRepositoryMock
-                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>()))
+                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), CancellationToken.None))
                 .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("whatever")));
 
             blobRepositoryMock
@@ -197,7 +197,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             applicationRepositoryMock
-                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>(), CancellationToken.None))
                 .ReturnsAsync(new Application()
                 {
                     DataTypes = new List<DataType>()

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -172,7 +172,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             blobRepositoryMock
-                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken?>()))
+                .Setup(d => d.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("whatever")));
 
             blobRepositoryMock
@@ -197,7 +197,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             });
 
             applicationRepositoryMock
-                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>()))
+                .Setup(ar => ar.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Application()
                 {
                     DataTypes = new List<DataType>()

--- a/test/UnitTest/TestingControllers/SignControllerTests.cs
+++ b/test/UnitTest/TestingControllers/SignControllerTests.cs
@@ -68,7 +68,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<ISigningService> instanceServiceMock = new Mock<ISigningService>();
             instanceServiceMock.Setup(ism => 
-            ism.CreateSignDocument(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ism.CreateSignDocument(It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((true, null));
 
             HttpClient client = GetTestClient(instanceServiceMock);
@@ -146,7 +146,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
             Mock<ISigningService> instanceServiceMock = new Mock<ISigningService>();
             instanceServiceMock.Setup(ism => 
-            ism.CreateSignDocument(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            ism.CreateSignDocument(It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((false, new ServiceError(404, "Instance not found")));
             
             HttpClient client = GetTestClient(instanceServiceMock);

--- a/test/UnitTest/TestingControllers/SignControllerTests.cs
+++ b/test/UnitTest/TestingControllers/SignControllerTests.cs
@@ -66,7 +66,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             string instanceGuid = "1916cd18-3b8e-46f8-aeaf-4bc3397ddd55";
             string requestUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}/sign";
 
-            Mock<IInstanceService> instanceServiceMock = new Mock<IInstanceService>();
+            Mock<ISigningService> instanceServiceMock = new Mock<ISigningService>();
             instanceServiceMock.Setup(ism => 
             ism.CreateSignDocument(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((true, null));
@@ -144,7 +144,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             string instanceGuid = "1916cd18-3b8e-46f8-aeaf-4bc3397ddd55";
             string requestUri = $"{BasePath}/{instanceOwnerPartyId}/{instanceGuid}/sign";
 
-            Mock<IInstanceService> instanceServiceMock = new Mock<IInstanceService>();
+            Mock<ISigningService> instanceServiceMock = new Mock<ISigningService>();
             instanceServiceMock.Setup(ism => 
             ism.CreateSignDocument(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<SignRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((false, new ServiceError(404, "Instance not found")));
@@ -170,7 +170,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        private HttpClient GetTestClient(Mock<IInstanceService> instanceServiceMock = null)
+        private HttpClient GetTestClient(Mock<ISigningService> instanceServiceMock = null)
         {
             // No setup required for these services. They are not in use by the InstanceController
             Mock<IKeyVaultClientWrapper> keyVaultWrapper = new Mock<IKeyVaultClientWrapper>();

--- a/test/UnitTest/TestingControllers/SignControllerTests.cs
+++ b/test/UnitTest/TestingControllers/SignControllerTests.cs
@@ -55,8 +55,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
 
         public static TheoryData<Signee> SigneeData => new(
             new Signee() { UserId = "1337", PersonNumber = "22117612345", SystemUserId = null, OrganisationNumber = null },
-            new Signee() { UserId = string.Empty, PersonNumber = null, SystemUserId = Guid.Parse("f58fe166-bc22-4899-beb7-c3e8e3332f43"), OrganisationNumber = "524446332" },
-            new Signee() { UserId = null, PersonNumber = null, SystemUserId = Guid.Parse("f58fe166-bc22-4899-beb7-c3e8e3332f43"), OrganisationNumber = "524446332" });
+            new Signee() { PersonNumber = null, SystemUserId = Guid.Parse("f58fe166-bc22-4899-beb7-c3e8e3332f43"), OrganisationNumber = "524446332" });
 
         [Theory]
         [MemberData(nameof(SigneeData))]

--- a/test/UnitTest/TestingServices/ApplicationServiceTests.cs
+++ b/test/UnitTest/TestingServices/ApplicationServiceTests.cs
@@ -28,7 +28,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -61,7 +61,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -80,7 +80,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -118,7 +118,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Application expectedApp = new();
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
                 .ReturnsAsync(new Application());
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -129,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Assert
             Assert.NotNull(app);
             Assert.Null(error);
-            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None), Times.Once);
+            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()), Times.Once);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             string expectedOrg = "org123";
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
                 .ReturnsAsync((Application)null);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -166,7 +166,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var exception = new Exception("Test exception");
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
                 .ThrowsAsync(exception);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);

--- a/test/UnitTest/TestingServices/ApplicationServiceTests.cs
+++ b/test/UnitTest/TestingServices/ApplicationServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Models;
@@ -27,7 +28,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -60,7 +61,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -79,7 +80,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -117,7 +118,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Application expectedApp = new();
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
                 .ReturnsAsync(new Application());
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -128,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Assert
             Assert.NotNull(app);
             Assert.Null(error);
-            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg), Times.Once);
+            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None), Times.Once);
         }
 
         [Fact]
@@ -139,7 +140,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             string expectedOrg = "org123";
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
                 .ReturnsAsync((Application)null);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -165,7 +166,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var exception = new Exception("Test exception");
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, CancellationToken.None))
                 .ThrowsAsync(exception);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);

--- a/test/UnitTest/TestingServices/ApplicationServiceTests.cs
+++ b/test/UnitTest/TestingServices/ApplicationServiceTests.cs
@@ -28,7 +28,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -61,7 +61,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -80,7 +80,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Arrange
             Application application = CreateApplication("ttd", "test-app");
 
-            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(application);
+            _applicationRepositoryMock.Setup(arm => arm.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(application);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
 
@@ -118,7 +118,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Application expectedApp = new();
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Application());
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -129,7 +129,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             // Assert
             Assert.NotNull(app);
             Assert.Null(error);
-            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()), Times.Once);
+            _applicationRepositoryMock.Verify(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             string expectedOrg = "org123";
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Application)null);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);
@@ -166,7 +166,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var exception = new Exception("Test exception");
 
             _applicationRepositoryMock
-                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken?>()))
+                .Setup(repo => repo.FindOne(appId, expectedOrg, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(exception);
 
             ApplicationService applicationService = new(_applicationRepositoryMock.Object);

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             
             dataRepositoryMock.Setup(drm => drm.Read(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(dataElement);
             blobRepositoryMock.Setup(
-                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null, It.IsAny<CancellationToken?>()))
+                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MemoryStream(blobStorageBytes));
 
             DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             
             dataRepositoryMock.Setup(drm => drm.Read(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(dataElement);
             blobRepositoryMock.Setup(
-                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null, CancellationToken.None))
+                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null, It.IsAny<CancellationToken?>()))
                 .ReturnsAsync(new MemoryStream(blobStorageBytes));
 
             DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -23,8 +23,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
 
-            DataService target = new DataService(fileScanMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            DataService target = new DataService(fileScanMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
 
             Instance instance = new Instance();
             DataType dataType = new DataType { EnableFileScan = false };
@@ -45,8 +46,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
 
-            DataService target = new DataService(fileScanMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            DataService target = new DataService(fileScanMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
 
             Instance instance = new Instance { Id = "343243/guid" };
             DataType dataType = new DataType { EnableFileScan = true };
@@ -70,6 +72,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanQueueClientMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             Guid id = Guid.NewGuid();
             string blobStoragePath = "/ttd/some-app";
@@ -87,7 +90,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null))
                 .ReturnsAsync(new MemoryStream(blobStorageBytes));
 
-            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
             
             // Act
             (string fileHash, ServiceError serviceError) = await dataService.GenerateSha256Hash("ttd", Guid.NewGuid(), id, null);
@@ -105,8 +108,9 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanQueueClientMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
-
-            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
+            
+            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
 
             // Act
             (string fileHash, ServiceError serviceError) = await dataService.GenerateSha256Hash("ttd", Guid.NewGuid(), Guid.NewGuid(), null);
@@ -123,6 +127,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanQueueClientMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             DataElement dataElement = new DataElement
             {
@@ -132,7 +137,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             
             dataRepositoryMock.Setup(drm => drm.Read(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(dataElement);
 
-            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
 
             // Act
             (string fileHash, ServiceError serviceError) = await dataService.GenerateSha256Hash("ttd", Guid.NewGuid(), Guid.NewGuid(), null);
@@ -149,6 +154,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Mock<IFileScanQueueClient> fileScanQueueClientMock = new Mock<IFileScanQueueClient>();
             Mock<IDataRepository> dataRepositoryMock = new Mock<IDataRepository>();
             Mock<IBlobRepository> blobRepositoryMock = new Mock<IBlobRepository>();
+            Mock<IInstanceEventService> instanceEventServiceMock = new Mock<IInstanceEventService>();
+            
             blobRepositoryMock.Setup(
                 drm => drm.WriteBlob(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<int?>()))
                 .ReturnsAsync((666, DateTimeOffset.Now));
@@ -159,7 +166,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 BlobStoragePath = "/ttd/some-app"
             };
 
-            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object);
+            DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);
 
             // Act
             await dataService.UploadDataAndCreateDataElement("ttd", new MemoryStream(Encoding.UTF8.GetBytes("whatever")), dataElement, 0, null);

--- a/test/UnitTest/TestingServices/DataServiceTests.cs
+++ b/test/UnitTest/TestingServices/DataServiceTests.cs
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             
             dataRepositoryMock.Setup(drm => drm.Read(It.IsAny<Guid>(), It.IsAny<Guid>())).ReturnsAsync(dataElement);
             blobRepositoryMock.Setup(
-                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null))
+                drm => drm.ReadBlob(It.IsAny<string>(), blobStoragePath, null, CancellationToken.None))
                 .ReturnsAsync(new MemoryStream(blobStorageBytes));
 
             DataService dataService = new DataService(fileScanQueueClientMock.Object, dataRepositoryMock.Object, blobRepositoryMock.Object, instanceEventServiceMock.Object);

--- a/test/UnitTest/TestingServices/SigningServiceTest.cs
+++ b/test/UnitTest/TestingServices/SigningServiceTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
 
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             // Act
             var performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, It.IsAny<CancellationToken>());
 
             // Assert
             Assert.True(created);
@@ -149,10 +149,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
 
             blobRepositoryMock.Setup(x => x.DeleteBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(true);
             
@@ -177,7 +177,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             };
             
             string? performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, It.IsAny<CancellationToken>());
 
             // Assert
             Assert.True(created);
@@ -203,7 +203,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
             
@@ -219,7 +219,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 loggerMock.Object);
 
             // Act
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", It.IsAny<CancellationToken>());
 
             // Assert
             Assert.False(created);
@@ -247,10 +247,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             
@@ -264,7 +264,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 loggerMock.Object);
 
             // Act
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", It.IsAny<CancellationToken>());
 
             // Assert
             Assert.False(created);
@@ -291,7 +291,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 .ReturnsAsync((true, null));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
 
             var dataServiceMock = new Mock<IDataService>();
             dataServiceMock.Setup(
@@ -301,7 +301,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             
@@ -326,7 +326,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             // Act
             var performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, It.IsAny<CancellationToken>());
 
             // Assert
             Assert.False(created);

--- a/test/UnitTest/TestingServices/SigningServiceTest.cs
+++ b/test/UnitTest/TestingServices/SigningServiceTest.cs
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             // Act
             var performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(1337, Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
 
             // Assert
             Assert.True(created);
@@ -177,7 +177,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             };
             
             string? performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(1337, Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
 
             // Assert
             Assert.True(created);
@@ -219,7 +219,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 loggerMock.Object);
 
             // Act
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(1337, Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
 
             // Assert
             Assert.False(created);
@@ -264,7 +264,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 loggerMock.Object);
 
             // Act
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(1337, Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), new SignRequest(), "1337", CancellationToken.None);
 
             // Assert
             Assert.False(created);
@@ -326,7 +326,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
 
             // Act
             var performedBy = !string.IsNullOrWhiteSpace(signee.UserId) ? signee.UserId : signee.OrganisationNumber;
-            (bool created, ServiceError serviceError) = await service.CreateSignDocument(1337, Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
+            (bool created, ServiceError serviceError) = await service.CreateSignDocument(Guid.NewGuid(), signRequest, performedBy, CancellationToken.None);
 
             // Assert
             Assert.False(created);

--- a/test/UnitTest/TestingServices/SigningServiceTest.cs
+++ b/test/UnitTest/TestingServices/SigningServiceTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
 
@@ -127,7 +127,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 Data = [oldSignatureDataElement]
             };
             
-            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), false, It.IsAny<CancellationToken>())).ReturnsAsync((instance, 0));
+            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((instance, 0));
 
             var applicationServiceMock = new Mock<IApplicationService>();
             applicationServiceMock.Setup(
@@ -149,10 +149,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null)).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
 
             blobRepositoryMock.Setup(x => x.DeleteBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(true);
             
@@ -203,7 +203,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
             
@@ -247,10 +247,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null)).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             
@@ -291,7 +291,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 .ReturnsAsync((true, null));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var dataServiceMock = new Mock<IDataService>();
             dataServiceMock.Setup(
@@ -301,7 +301,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null)).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             

--- a/test/UnitTest/TestingServices/SigningServiceTest.cs
+++ b/test/UnitTest/TestingServices/SigningServiceTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
 
@@ -149,10 +149,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 esm => esm.DispatchEvent(It.Is<InstanceEventType>(ies => ies == InstanceEventType.Signed), It.IsAny<Instance>()));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream(JsonSerializer.SerializeToUtf8Bytes(oldSignDocument)));
 
             blobRepositoryMock.Setup(x => x.DeleteBlob(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>())).ReturnsAsync(true);
             
@@ -203,7 +203,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
             
@@ -247,10 +247,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
             
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             
@@ -291,7 +291,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                 .ReturnsAsync((true, null));
 
             var applicationRepositoryMock = new Mock<IApplicationRepository>();
-            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken?>())).ReturnsAsync(new Application());
+            applicationRepositoryMock.Setup(am => am.FindOne(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Application());
 
             var dataServiceMock = new Mock<IDataService>();
             dataServiceMock.Setup(
@@ -301,7 +301,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             var instanceEventServiceMock = new Mock<IInstanceEventService>();
 
             var blobRepositoryMock = new Mock<IBlobRepository>();
-            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken?>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
+            blobRepositoryMock.Setup(x => x.ReadBlob(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>())).ReturnsAsync(new MemoryStream("whatever"u8.ToArray()));
             
             var loggerMock = new Mock<ILogger<SigningService>>();
             

--- a/test/UnitTest/TestingServices/SigningServiceTest.cs
+++ b/test/UnitTest/TestingServices/SigningServiceTest.cs
@@ -36,7 +36,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         {
             // Arrange
             var instanceRepositoryMock = new Mock<IInstanceRepository>();
-            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), false, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
+            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
             {
                 InstanceOwner = new(),
                 Process = new ProcessState { CurrentTask = new ProcessElementInfo { AltinnTaskType = "CurrentTask" } },
@@ -196,7 +196,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         {
             // Arrange
             var instanceRepositoryMock = new Mock<IInstanceRepository>();
-            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(((Instance?)null, 0));
+            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync(((Instance?)null, 0));
 
             var applicationServiceMock = new Mock<IApplicationService>();
             var dataServiceMock = new Mock<IDataService>();
@@ -232,7 +232,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         {
             // Arrange
             var instanceRepositoryMock = new Mock<IInstanceRepository>();
-            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), false, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
+            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
             {
                 InstanceOwner = new(),
                 Process = new ProcessState { CurrentTask = new ProcessElementInfo { AltinnTaskType = "CurrentTask" } }
@@ -279,7 +279,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         {
             // Arrange
             var instanceRepositoryMock = new Mock<IInstanceRepository>();
-            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), false, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
+            instanceRepositoryMock.Setup(rm => rm.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((new Instance()
             {
                 InstanceOwner = new(),
                 Process = new ProcessState { CurrentTask = new ProcessElementInfo { AltinnTaskType = "CurrentTask" } }


### PR DESCRIPTION
If there is already a signature data element for the signee performing sign, delete the existing signature.

Rename InstanceService to SigningService.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for immediate deletion of data elements and their associated blobs, with event dispatching.
  - Introduced a dedicated signing service for creating signature documents within instances, including removal of old signatures for the same signee and data type.

- **Improvements**
  - Enhanced cancellation support for asynchronous operations across repositories and services.
  - Updated service dependencies and controller logic to use the new signing service with streamlined method signatures.

- **Bug Fixes**
  - Corrected minor documentation typos for improved clarity.

- **Tests**
  - Updated unit tests to reflect new service interfaces, method signatures, and dependency injections.
  - Added a test verifying deletion of old signature documents when creating a new signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->