### PR TITLE
Change process next authorization to be more lenient. More actions are accepted for running process next. Depends on task type.

### DIFF
--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -301,7 +301,7 @@ namespace Altinn.Platform.Storage.Controllers
                 "payment" => ["pay", "write"],
                 "confirmation" => ["confirm"],
                 "signing" => ["sign", "write"],
-                _ => [taskType, "write"],
+                _ => [taskType]
             };
         }
     }

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -292,7 +292,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// <summary>
         /// Get all actions that allow process next for the given task type. Meant to be used to authorize the process next when no action is provided.
         /// </summary>
-        /// <remarks>To allow process next for a custom action, user needs to have access to an action with the same name as the task type, or alternatively 'write', in the policy.</remarks>
+        /// <remarks>To allow process next for a custom action, user needs to have access to an action with the same name as the task type in the policy.</remarks>
         private static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
         {
             return taskType switch

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -293,7 +293,7 @@ namespace Altinn.Platform.Storage.Controllers
         /// Get all actions that allow process next for the given task type. Meant to be used to authorize the process next when no action is provided.
         /// </summary>
         /// <remarks>To allow process next for a custom action, user needs to have access to an action with the same name as the task type in the policy.</remarks>
-        private static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
+        public static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
         {
             return taskType switch
             {

--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -87,11 +87,9 @@ namespace Altinn.Platform.Storage.Controllers
                 return NotFound();
             }
 
-            var (action, taskId) = ActionMapping(processState, existingInstance);
+            bool atLeastOneActionAuthorized = await AuthorizeProcessNext(processState, existingInstance);
 
-            bool authorized = await _authorizationService.AuthorizeInstanceAction(existingInstance, action, taskId);
-
-            if (!authorized)
+            if (!atLeastOneActionAuthorized)
             {
                 return Forbid();
             }
@@ -153,11 +151,9 @@ namespace Altinn.Platform.Storage.Controllers
 
             ProcessState processState = processStateUpdate.State;
 
-            var (action, taskId) = ActionMapping(processState, existingInstance);
+            bool atLeastOneActionAuthorized = await AuthorizeProcessNext(processState, existingInstance);
 
-            bool authorized = await _authorizationService.AuthorizeInstanceAction(existingInstance, action, taskId);
-
-            if (!authorized)
+            if (!atLeastOneActionAuthorized)
             {
                 return Forbid();
             }
@@ -253,33 +249,60 @@ namespace Altinn.Platform.Storage.Controllers
             existingInstance.LastChangedBy = User.GetUserOrOrgNo();
             existingInstance.LastChanged = DateTime.UtcNow;
         }
-
-        private (string Action, string TaskId) ActionMapping(ProcessState processState, Instance existingInstance)
+        
+        private async Task<bool> AuthorizeProcessNext(ProcessState processState, Instance existingInstance)
         {
-            string taskId = null;
+            (string[] actionsThatAllowProcessNext, string taskId) = GetActionsToAuthorize(processState, existingInstance);
+
+            foreach (string action in actionsThatAllowProcessNext)
+            {
+                bool actionIsAuthorized = await _authorizationService.AuthorizeInstanceAction(existingInstance, action, taskId);
+                if (actionIsAuthorized)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static (string[] Actions, string TaskId) GetActionsToAuthorize(ProcessState processState, Instance existingInstance)
+        {
+            string taskId = existingInstance.Process?.CurrentTask?.ElementId;
             string altinnTaskType = existingInstance.Process?.CurrentTask?.AltinnTaskType;
 
             if (processState?.CurrentTask?.FlowType == "AbandonCurrentMoveToNext")
             {
-                altinnTaskType = "reject";
+                return (["reject"], taskId);
             }
-            else if (processState?.CurrentTask?.FlowType is not null
+            
+            // Think this IF is related to gateways, but not sure.
+            if (processState?.CurrentTask?.FlowType is not null
                 && processState.CurrentTask.FlowType != "CompleteCurrentMoveToNext")
             {
                 altinnTaskType = processState.CurrentTask.AltinnTaskType;
                 taskId = processState.CurrentTask.ElementId;
             }
+            
+            string[] actionsThatAllowProcessNextForTaskType = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
 
-            string action = altinnTaskType switch
+            return (actionsThatAllowProcessNextForTaskType, taskId);
+        }
+        
+        /// <summary>
+        /// Get all actions that allow process next for the given task type. Meant to be used to authorize the process next when no action is provided.
+        /// </summary>
+        /// <remarks>To allow process next for a custom action, user needs to have access to an action with the same name as the task type, or alternatively 'write', in the policy.</remarks>
+        private static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
+        {
+            return taskType switch
             {
-                "data" or "feedback" => "write",
-                "payment" => "pay",
-                "confirmation" => "confirm",
-                "signing" => "sign",
-                _ => altinnTaskType,
+                "data" or "feedback" => ["write"],
+                "payment" => ["pay", "write"],
+                "confirmation" => ["confirm"],
+                "signing" => ["sign", "write"],
+                _ => [taskType, "write"],
             };
-
-            return (action, taskId);
         }
     }
 }

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -205,6 +205,84 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
+        
+        /// <summary>
+        /// Test case: User is Authorized
+        /// Expected: Returns status ok. 
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(UpdateTestParameters))]
+        public async Task PutProcess_UserIsAuthorized_OnlyHasSignRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(3, 1337, 3);
+            Instance testInstance = TestDataUtil.GetInstance(new Guid("377efa97-80ee-4cc6-8d48-09de12cc273d"));
+            testInstance.Id = $"{testInstance.InstanceOwner.PartyId}/{testInstance.Id}";
+
+            testInstance.Process.CurrentTask = new ProcessElementInfo()
+            {
+                ElementId = "Task_2",
+                AltinnTaskType = "signing",
+                FlowType = "CompleteCurrentMoveToNext"
+            };
+            
+            var instanceRepoMock = new Mock<IInstanceRepository>();
+            instanceRepoMock.Setup(ir => ir.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((testInstance, 0));
+            instanceRepoMock.Setup(ir => ir.Update(testInstance, It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(testInstance);
+            
+            // Act
+            using HttpResponseMessage response = await SendUpdateRequest(useInstanceAndEventsEndpoint, token: token, instanceId: testInstance.Id, instanceRepository: instanceRepoMock.Object, configure: state =>
+            {
+                state.CurrentTask = new ProcessElementInfo
+                {
+                    ElementId = "Task_3",
+                    AltinnTaskType = "data",
+                    FlowType = "CompleteCurrentMoveToNext"
+                };
+            });
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        
+        /// <summary>
+        /// Test case: User is Authorized
+        /// Expected: Returns status ok. 
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(UpdateTestParameters))]
+        public async Task PutProcess_UserIsAuthorized_OnlyHasWriteRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(3, 1337, 3);
+            Instance testInstance = TestDataUtil.GetInstance(new Guid("377efa97-80ee-4cc6-8d48-09de12cc273d"));
+            testInstance.Id = $"{testInstance.InstanceOwner.PartyId}/{testInstance.Id}";
+
+            testInstance.Process.CurrentTask = new ProcessElementInfo()
+            {
+                ElementId = "Task_3",
+                AltinnTaskType = "signing",
+                FlowType = "CompleteCurrentMoveToNext"
+            };
+            
+            var instanceRepoMock = new Mock<IInstanceRepository>();
+            instanceRepoMock.Setup(ir => ir.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((testInstance, 0));
+            instanceRepoMock.Setup(ir => ir.Update(testInstance, It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(testInstance);
+            
+            // Act
+            using HttpResponseMessage response = await SendUpdateRequest(useInstanceAndEventsEndpoint, token: token, instanceId: testInstance.Id, instanceRepository: instanceRepoMock.Object, configure: state =>
+            {
+                state.CurrentTask = new ProcessElementInfo
+                {
+                    ElementId = "Task_4",
+                    AltinnTaskType = "data",
+                    FlowType = "CompleteCurrentMoveToNext"
+                };
+            });
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
 
         /// <summary>
         /// Test case: Uses want to go back to a earlier state

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -212,7 +212,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         /// </summary>
         [Theory]
         [MemberData(nameof(UpdateTestParameters))]
-        public async Task PutProcess_UserIsAuthorized_OnlyHasSignRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        public async Task PutProcess_UserIsAuthorized_Signing_OnlyHasSignRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
         {
             // Arrange
             string token = PrincipalUtil.GetToken(3, 1337, 3);
@@ -251,7 +251,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         /// </summary>
         [Theory]
         [MemberData(nameof(UpdateTestParameters))]
-        public async Task PutProcess_UserIsAuthorized_OnlyHasWriteRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        public async Task PutProcess_UserIsAuthorized_Signing_OnlyHasWriteRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
         {
             // Arrange
             string token = PrincipalUtil.GetToken(3, 1337, 3);
@@ -275,6 +275,84 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 state.CurrentTask = new ProcessElementInfo
                 {
                     ElementId = "Task_4",
+                    AltinnTaskType = "data",
+                    FlowType = "CompleteCurrentMoveToNext"
+                };
+            });
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        
+        /// <summary>
+        /// Test case: User is Authorized
+        /// Expected: Returns status ok. 
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(UpdateTestParameters))]
+        public async Task PutProcess_UserIsAuthorized_Payment_OnlyHasWriteRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(3, 1337, 3);
+            Instance testInstance = TestDataUtil.GetInstance(new Guid("377efa97-80ee-4cc6-8d48-09de12cc273d"));
+            testInstance.Id = $"{testInstance.InstanceOwner.PartyId}/{testInstance.Id}";
+
+            testInstance.Process.CurrentTask = new ProcessElementInfo()
+            {
+                ElementId = "Task_3",
+                AltinnTaskType = "payment",
+                FlowType = "CompleteCurrentMoveToNext"
+            };
+            
+            var instanceRepoMock = new Mock<IInstanceRepository>();
+            instanceRepoMock.Setup(ir => ir.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((testInstance, 0));
+            instanceRepoMock.Setup(ir => ir.Update(testInstance, It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(testInstance);
+            
+            // Act
+            using HttpResponseMessage response = await SendUpdateRequest(useInstanceAndEventsEndpoint, token: token, instanceId: testInstance.Id, instanceRepository: instanceRepoMock.Object, configure: state =>
+            {
+                state.CurrentTask = new ProcessElementInfo
+                {
+                    ElementId = "Task_4",
+                    AltinnTaskType = "data",
+                    FlowType = "CompleteCurrentMoveToNext"
+                };
+            });
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        
+        /// <summary>
+        /// Test case: User is Authorized
+        /// Expected: Returns status ok. 
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(UpdateTestParameters))]
+        public async Task PutProcess_UserIsAuthorized_CustomTaskType_OnlyHasWriteRights_ReturnsStatusOK(bool useInstanceAndEventsEndpoint)
+        {
+            // Arrange
+            string token = PrincipalUtil.GetToken(3, 1337, 3);
+            Instance testInstance = TestDataUtil.GetInstance(new Guid("377efa97-80ee-4cc6-8d48-09de12cc273d"));
+            testInstance.Id = $"{testInstance.InstanceOwner.PartyId}/{testInstance.Id}";
+
+            testInstance.Process.CurrentTask = new ProcessElementInfo()
+            {
+                ElementId = "Task_4",
+                AltinnTaskType = "custom-task-type",
+                FlowType = "CompleteCurrentMoveToNext"
+            };
+            
+            var instanceRepoMock = new Mock<IInstanceRepository>();
+            instanceRepoMock.Setup(ir => ir.GetOne(It.IsAny<Guid>(), true, It.IsAny<CancellationToken>())).ReturnsAsync((testInstance, 0));
+            instanceRepoMock.Setup(ir => ir.Update(testInstance, It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(testInstance);
+            
+            // Act
+            using HttpResponseMessage response = await SendUpdateRequest(useInstanceAndEventsEndpoint, token: token, instanceId: testInstance.Id, instanceRepository: instanceRepoMock.Object, configure: state =>
+            {
+                state.CurrentTask = new ProcessElementInfo
+                {
+                    ElementId = "Task_5",
                     AltinnTaskType = "data",
                     FlowType = "CompleteCurrentMoveToNext"
                 };

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -399,6 +399,22 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
+        
+        [Theory]
+        [InlineData("data", new[] { "write" })]
+        [InlineData("feedback", new[] { "write" })]
+        [InlineData("payment", new[] { "pay", "write" })]
+        [InlineData("confirmation", new[] { "confirm" })]
+        [InlineData("signing", new[] { "sign", "write" })]
+        [InlineData("customTask", new[] { "customTask" })]
+        public void GetActionsThatAllowProcessNextForTaskType_ReturnsExpectedActions(string taskType, string[] expectedActions)
+        {
+            // Act
+            string[] result = ProcessController.GetActionsThatAllowProcessNextForTaskType(taskType);
+
+            // Assert
+            Assert.Equal(expectedActions, result);
+        }
 
         private HttpClient GetTestClient(IInstanceRepository instanceRepository = null, IInstanceAndEventsRepository instanceAndEventsRepository = null)
         {

--- a/test/UnitTest/data/apps/tdd/endring-av-navn/config/authorization/policy.xml
+++ b/test/UnitTest/data/apps/tdd/endring-av-navn/config/authorization/policy.xml
@@ -193,6 +193,49 @@
       </xacml:AnyOf>
     </xacml:Target>
   </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:8" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can sign for tdd/endring-av-navn when it is in Task_4</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">tdd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">endring-av-navn</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_4</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">custom-task-type</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
   <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
     <xacml:Description>Rule that defines that user with role REGNA or DAGL can read and write for tdd/endring-av-navn when it is in Task_1</xacml:Description>
     <xacml:Target>

--- a/test/UnitTest/data/apps/tdd/endring-av-navn/config/authorization/policy.xml
+++ b/test/UnitTest/data/apps/tdd/endring-av-navn/config/authorization/policy.xml
@@ -107,6 +107,92 @@
       </xacml:AnyOf>
     </xacml:Target>
   </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:6" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can sign for tdd/endring-av-navn when it is in Task_2</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">tdd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">endring-av-navn</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_2</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">sign</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
+  <xacml:Rule RuleId="urn:altinn:example:ruleid:7" Effect="Permit">
+    <xacml:Description>Rule that defines that user with role REGNA or DAGL can sign for tdd/endring-av-navn when it is in Task_3</xacml:Description>
+    <xacml:Target>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">REGNA</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DAGL</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:rolecode" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">tdd</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">endring-av-navn</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Task_3</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:altinn:task" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+      <xacml:AnyOf>
+        <xacml:AllOf>
+          <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+            <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">write</xacml:AttributeValue>
+            <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"/>
+          </xacml:Match>
+        </xacml:AllOf>
+      </xacml:AnyOf>
+    </xacml:Target>
+  </xacml:Rule>
   <xacml:Rule RuleId="urn:altinn:example:ruleid:2" Effect="Permit">
     <xacml:Description>Rule that defines that user with role REGNA or DAGL can read and write for tdd/endring-av-navn when it is in Task_1</xacml:Description>
     <xacml:Target>


### PR DESCRIPTION
Change process next authorization to be more lenient. More actions are accepted for running process next. Depends on task type.

## Description
We are in the process of changing the app-lib-code to accept more than one action as a valid process next action. For instance, in a signing task, we allow running process next both with action=sign and with no action, which is equal to action=write.

This is done to support that both these scenarios:
- Singing using process next with action sign.
- Singing using ActionController and then running a process next with no action.

```
POST /action/sign
POST /action/sign
POST /action/sign
PUT /process/next //Fails if number of signatures is less than minCount, or if other validation fails.

//AND
PUT /process/next { action=sign }
```

https://github.com/Altinn/app-lib-dotnet/blob/feature/signing/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs#L34


## Related Issue(s)
Fixes https://github.com/Altinn/app-lib-dotnet/issues/1165

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded authorization checks to allow multiple valid actions per task type when updating process states.
	- Updated authorization policy to permit signing, writing, and custom task actions for specific user roles in designated process steps.

- **Tests**
	- Added tests to ensure users with appropriate rights can update process states for various task types.
	- Added tests to verify the correct set of actions allowed for each task type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->