### PR TITLE
Remove unused settings

### DIFF
--- a/src/Storage/Configuration/AzureStorageConfiguration.cs
+++ b/src/Storage/Configuration/AzureStorageConfiguration.cs
@@ -21,24 +21,9 @@ namespace Altinn.Platform.Storage.Configuration
         public string AccountKey { get; set; }
 
         /// <summary>
-        /// name of the storage container in the storage account
-        /// </summary>
-        public string StorageContainer { get; set; }
-
-        /// <summary>
         /// url for the blob end point
         /// </summary>
         public string BlobEndPoint { get; set; }
-
-        /// <summary>
-        /// url for the app owner Key Vault
-        /// </summary>
-        public string OrgKeyVaultURI { get; set; }
-
-        /// <summary>
-        /// Dictionary containing alternative key vault names for app owner
-        /// </summary>
-        public string OrgKeyVaultDict { get; set; } = "{}";
 
         /// <summary>
         /// name of app owner storage account
@@ -46,18 +31,8 @@ namespace Altinn.Platform.Storage.Configuration
         public string OrgStorageAccount { get; set; }
 
         /// <summary>
-        /// name of SAS definition in app owner Key Vault
-        /// </summary>
-        public string OrgSasDefinition { get; set; }
-
-        /// <summary>
         /// name of storage container in app owner storage account
         /// </summary>
         public string OrgStorageContainer { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of hours old a shared access signature token can be before requesting a new.
-        /// </summary>
-        public int AllowedSasTokenAgeHours { get; set; }
     }
 }

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -10,13 +10,9 @@
   "AzureStorageConfiguration": {
     "AccountName": "devstoreaccount1",
     "AccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
-    "StorageContainer": "servicedata",
     "BlobEndPoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "OrgKeyVaultURI": "https://{0}-dev-keyvault.vault.azure.net/",
     "OrgStorageAccount": "{0}altinndevstrg01",
-    "OrgStorageContainer": "{0}-dev-appsdata-blob-db",
-    "OrgSasDefinition": "{0}devsasdef01",
-    "AllowedSasTokenAgeHours": 8
+    "OrgStorageContainer": "{0}-dev-appsdata-blob-db"
   },
   "GeneralSettings": {
     "OpenIdWellKnownEndpoint": "http://local.altinn.cloud/authentication/api/v1/openid/",

--- a/test/UnitTest/appsettings.unittest.json
+++ b/test/UnitTest/appsettings.unittest.json
@@ -8,13 +8,9 @@
   "AzureStorageConfiguration": {
     "AccountName": "devstoreaccount1",
     "AccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
-    "StorageContainer": "servicedata",
     "BlobEndPoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "OrgKeyVaultURI": "https://{0}-dev-keyvault.vault.azure.net/",
     "OrgStorageAccount": "{0}altinndevstorage01",
-    "OrgStorageContainer": "{0}-dev-appsdata-blob-db",
-    "OrgSasDefinition": "{0}devsasdef01",
-    "AllowedSasTokenAgeHours": 1
+    "OrgStorageContainer": "{0}-dev-appsdata-blob-db"
   },
   "GeneralSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid/",
@@ -25,8 +21,7 @@
     "InstanceSyncAdapterScope": "altinn:storage/instances.syncadapter",
     "AppTitleCacheLifeTimeInSeconds": 60,
     "AppMetadataCacheLifeTimeInSeconds": 60,
-    "TextResourceCacheLifeTimeInSeconds": 60,
-    "UsePostgreSQL": "false"
+    "TextResourceCacheLifeTimeInSeconds": 60
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/"


### PR DESCRIPTION
## Description
Removing some dead settings no longer in use by Storage. FileScan still rely on sas tokens to download blobs, but FileScan has it's own settings.