### PR TITLE
Update interface for signee.userid to make it nullable

### DIFF
--- a/src/Storage.Interface/Models/Signee.cs
+++ b/src/Storage.Interface/Models/Signee.cs
@@ -14,7 +14,7 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// The userId representing the signee.
         /// </summary>
         [JsonProperty(PropertyName = "userId")]
-        public string UserId { get; set; } = string.Empty;
+        public string? UserId { get; set; }
 
         /// <summary>
         /// The ID of the systemuser performing the signing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SignClient in app-lib-dotnet sends a null value for UserId if a systemuser is signing.
As signController in storage expects a non-null string, this leads to a 400 Bad Request.
Makes more sense to have it nullable in storage than to fallback to empty string in app-lib as there will be no set userId for a systemuser

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
