### PR TITLE
Add sync adapter settings

### DIFF
--- a/src/Storage.Interface/Models/MessageBoxConfig.cs
+++ b/src/Storage.Interface/Models/MessageBoxConfig.cs
@@ -13,5 +13,11 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "hideSettings")]
         public HideSettings HideSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sync adapter settings.
+        /// </summary>
+        [JsonProperty(PropertyName = "syncAdapterSettings")]
+        public SyncAdapterSettings SyncAdapterSettings { get; set; }
     }
 }

--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -46,12 +46,18 @@ namespace Altinn.Platform.Storage.Interface.Models
         public bool DisableAddTransmissions { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag controlling whether the sync adapter should disable synchronize adding attachments at the dialog level.
-        /// Will only add/remove attachments with recognized id's, which are derived from the URL.
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the visible from date.
         /// </summary>
-        [JsonProperty(PropertyName = "disableSyncAttachments")]
+        [JsonProperty(PropertyName = "disableSyncVisibleFrom")]
         [DefaultValue(false)]
-        public bool DisableSyncAttachments { get; set; }
+        public bool DisableSyncVisibleFrom { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the due at date.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncDueAt")]
+        [DefaultValue(false)]
+        public bool DisableSyncDueAt { get; set; }
 
         /// <summary>
         /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the status.
@@ -75,14 +81,24 @@ namespace Altinn.Platform.Storage.Interface.Models
         public bool DisableSyncContentSummary { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) API actions
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing attachments at the dialog level.
+        /// Will only add/remove attachments with recognized id's, which are derived from the URL.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncAttachments")]
+        [DefaultValue(false)]
+        public bool DisableSyncAttachments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing API actions.
+        /// Will only add/remove API actions with recognized id's, which are derived from the URL.
         /// </summary>
         [JsonProperty(PropertyName = "disableSyncApiActions")]
         [DefaultValue(false)]
         public bool DisableSyncApiActions { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) GUI actions
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing GUI actions.
+        /// Will only add/remove GUI actions with recognized id's, which are derived from the URL.
         /// </summary>
         [JsonProperty(PropertyName = "disableSyncGuiActions")]
         [DefaultValue(false)]

--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -46,13 +46,6 @@ namespace Altinn.Platform.Storage.Interface.Models
         public bool DisableAddTransmissions { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the visible from date.
-        /// </summary>
-        [JsonProperty(PropertyName = "disableSyncVisibleFrom")]
-        [DefaultValue(false)]
-        public bool DisableSyncVisibleFrom { get; set; }
-
-        /// <summary>
         /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the due at date.
         /// </summary>
         [JsonProperty(PropertyName = "disableSyncDueAt")]

--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Altinn.Platform.Storage.Interface.Models
+{
+    /// <summary>
+    /// A class to hold sync adapter settings
+    /// </summary>
+    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+    public class SyncAdapterSettings
+    {
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable all dialog synchronization.
+        /// This overrides all other settings.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSync")]
+        [DefaultValue(false)]
+        public bool DisableSync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable dialog creation.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableCreate")]
+        [DefaultValue(false)]
+        public bool DisableCreate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable dialog deletion.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableDelete")]
+        [DefaultValue(false)]
+        public bool DisableDelete { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable adding activities.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableAddActivities")]
+        [DefaultValue(false)]
+        public bool DisableAddActivities { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable adding transmissions.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableAddTransmissions")]
+        [DefaultValue(false)]
+        public bool DisableAddTransmissions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronize adding attachments at the dialog level.
+        /// Will only add/remove attachments with recognized id's, which are derived from the URL.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncAttachments")]
+        [DefaultValue(false)]
+        public bool DisableSyncAttachments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the status.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncStatus")]
+        [DefaultValue(false)]
+        public bool DisableSyncStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the title.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncContentTitle")]
+        [DefaultValue(false)]
+        public bool DisableSyncContentTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the summary.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncContentSummary")]
+        [DefaultValue(false)]
+        public bool DisableSyncContentSummary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) API actions
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncApiActions")]
+        [DefaultValue(false)]
+        public bool DisableSyncApiActions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) GUI actions
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncGuiActions")]
+        [DefaultValue(false)]
+        public bool DisableSyncGuiActions { get; set; }
+    }
+}


### PR DESCRIPTION
## Description
This expands MessageBoxConfig with a new setting for controlling Dialogporten Adapter sync

## Related Issue(s)
- #685 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable synchronization settings, allowing users to selectively enable or disable various sync adapter functionalities such as synchronization, creation, deletion, activities, transmissions, and specific dialog attributes. These options provide enhanced control over synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->