### PR TITLE
Feature/sign doc system text json support

### DIFF
--- a/src/Storage.Interface/Models/SignDocument.cs
+++ b/src/Storage.Interface/Models/SignDocument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 #nullable enable
@@ -14,30 +15,35 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// Unique id of the SignDocument (identical to dataElementId for this document).
         /// </summary>
         [JsonProperty(PropertyName = "id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
 
         /// <summary>
         /// Instance guid.
         /// </summary>
         [JsonProperty(PropertyName = "instanceGuid")]
+        [JsonPropertyName("instanceGuid")]
         public string InstanceGuid { get; set; } = string.Empty;  
 
         /// <summary>
         /// Timestamp for when the document was signed.
         /// </summary>
         [JsonProperty(PropertyName = "signedTime")]
+        [JsonPropertyName("signedTime")]
         public DateTime SignedTime { get; set; }
         
         /// <summary>
         /// Information about the signee.
         /// </summary>
         [JsonProperty(PropertyName = "signeeInfo")]
+        [JsonPropertyName("signeeInfo")]
         public Signee SigneeInfo { get; set; } = new Signee();
 
         /// <summary>
         /// List of dataElementSignatures.
         /// </summary>
         [JsonProperty(PropertyName = "dataElementSignatures")]
+        [JsonPropertyName("dataElementSignatures")]
         public List<DataElementSignature> DataElementSignatures { get; set; } = new List<DataElementSignature>();
         
         /// <summary>
@@ -49,18 +55,21 @@ namespace Altinn.Platform.Storage.Interface.Models
             /// Id of the dataElement.
             /// </summary>
             [JsonProperty(PropertyName = "dataElementId")]
+            [JsonPropertyName("dataElementId")]
             public string DataElementId { get; set; } = string.Empty;
 
             /// <summary>
             /// Sha256 hash of the dataelement.
             /// </summary>
             [JsonProperty(PropertyName = "sha256Hash")]
+            [JsonPropertyName("sha256Hash")]
             public string Sha256Hash { get; set; } = string.Empty;
 
             /// <summary>
             /// Signing status for dataElement.
             /// </summary>
             [JsonProperty(PropertyName = "signed")]
+            [JsonPropertyName("signed")]
             public bool Signed { get; set; }
         }
     }

--- a/src/Storage.Interface/Models/Signee.cs
+++ b/src/Storage.Interface/Models/Signee.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable 
 
 using System;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Storage.Interface.Models
@@ -14,24 +15,28 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// The userId representing the signee.
         /// </summary>
         [JsonProperty(PropertyName = "userId")]
+        [JsonPropertyName("userId")]
         public string? UserId { get; set; }
 
         /// <summary>
         /// The ID of the systemuser performing the signing
         /// </summary>
         [JsonProperty(PropertyName = "systemUserId")]
+        [JsonPropertyName("systemUserId")]
         public Guid? SystemUserId { get; set; }
 
         /// <summary>
         /// The personNumber representing the signee.
         /// </summary>
         [JsonProperty(PropertyName = "personNumber")]
+        [JsonPropertyName("personNumber")]
         public string? PersonNumber { get; set; }
 
         /// <summary>
         /// The organisationNumber representing the signee.
         /// </summary>
         [JsonProperty(PropertyName = "organisationNumber")]
+        [JsonPropertyName("organisationNumber")]
         public string? OrganisationNumber { get; set; }
     }
 }

--- a/src/Storage/Services/SigningService.cs
+++ b/src/Storage/Services/SigningService.cs
@@ -26,7 +26,7 @@ namespace Altinn.Platform.Storage.Services
         private readonly IDataService _dataService;
         private readonly IApplicationService _applicationService;
         private readonly IInstanceEventService _instanceEventService;
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerOptions.Web) { WriteIndented = true };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SigningService"/> class.


### PR DESCRIPTION
After changing to System.Text.Json i SigningService (InstanceService), the property name attributes in SignDocument were no longer respected.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved compatibility with multiple JSON serialization libraries for document signing features, ensuring consistent property naming in JSON outputs.
- **Chores**
	- Updated internal serialization settings to align with modern web standards while maintaining readable JSON formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->