### PR TITLE
Add dummy end event for auth requests for migrated elements

### DIFF
--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -376,6 +376,11 @@ public class AuthorizationService(
             {
                 resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(XacmlResourceEndId, instance.Process.EndEvent, DefaultType, DefaultIssuer));
             }
+            else if (instance.DataValues != null && (instance.DataValues.ContainsKey("A1ArchRef") || instance.DataValues.ContainsKey("A2ArchRef")))
+            {
+                // Add a dummy end event for migrated a1/a2 instances
+                resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(XacmlResourceEndId, "MigratedA1A2", DefaultType, DefaultIssuer));
+            }
 
             if (!string.IsNullOrWhiteSpace(instanceProps.InstanceId))
             {

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -160,6 +160,84 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         }
 
         /// <summary>
+        /// Test case: Migrated A2 instances
+        /// Expected: Dummy end events are added
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonMultipleRequest_TC03()
+        {
+            // Arrange
+            List<string> actionTypes = new List<string> { "read", "write" };
+            List<Instance> instances = CreateInstances();
+            foreach (Instance instance in instances)
+            {
+                // Add data values to the instances
+                instance.DataValues = new() { { "A2ArchRef", "test" } };
+            }
+
+            // Act
+            XacmlJsonRequestRoot requestRoot = AuthorizationService.CreateMultiDecisionRequest(CreateUserClaims(1), instances, actionTypes);
+
+            // Assert
+            requestRoot.Request.Resource.ForEach(resource =>
+            {
+                Assert.Contains(resource.Attribute, attr => attr.AttributeId == "urn:altinn:end-event" && attr.Value == "MigratedA1A2");
+            });
+        }
+
+        /// <summary>
+        /// Test case: Migrated A1 instances
+        /// Expected: Dummy end events are added
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonMultipleRequest_TC04()
+        {
+            // Arrange
+            List<string> actionTypes = new List<string> { "read", "write" };
+            List<Instance> instances = CreateInstances();
+            foreach (Instance instance in instances)
+            {
+                // Add data values to the instances
+                instance.DataValues = new() { { "A1ArchRef", "test" } };
+            }
+
+            // Act
+            XacmlJsonRequestRoot requestRoot = AuthorizationService.CreateMultiDecisionRequest(CreateUserClaims(1), instances, actionTypes);
+
+            // Assert
+            requestRoot.Request.Resource.ForEach(resource =>
+            {
+                Assert.Contains(resource.Attribute, attr => attr.AttributeId == "urn:altinn:end-event" && attr.Value == "MigratedA1A2");
+            });
+        }
+
+        /// <summary>
+        /// Test case: Normal A3 instances
+        /// Expected: Dummy end events are not added
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonMultipleRequest_TC05()
+        {
+            // Arrange
+            List<string> actionTypes = new List<string> { "read", "write" };
+            List<Instance> instances = CreateInstances();
+            foreach (Instance instance in instances)
+            {
+                // Add data values to the instances
+                instance.DataValues = new() { { "SomeValue", "test" } };
+            }
+
+            // Act
+            XacmlJsonRequestRoot requestRoot = AuthorizationService.CreateMultiDecisionRequest(CreateUserClaims(1), instances, actionTypes);
+
+            // Assert
+            requestRoot.Request.Resource.ForEach(resource =>
+            {
+                Assert.DoesNotContain(resource.Attribute, attr => attr.AttributeId == "urn:altinn:end-event" && attr.Value == "MigratedA1A2");
+            });
+        }
+
+        /// <summary>
         /// Test case: Authorize an convert emtpy list of instances to messageboxInstances
         /// Expected: An empty list is returned.
         /// </summary>


### PR DESCRIPTION
## Description
Added dummy end event for auth requests for migrated elements

## Related Issue(s)
- #677

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Instances identified as migrated A1/A2 now display a placeholder end event in resource categories, improving representation in authorization requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->