### PR TITLE
added includeAttachments to CopyInstanceSettings

### DIFF
--- a/src/Storage.Interface/Models/CopyInstanceSettings.cs
+++ b/src/Storage.Interface/Models/CopyInstanceSettings.cs
@@ -26,5 +26,12 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "excludedDataFields")]
         public List<string> ExcludedDataFields { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a boolean indicating if copying of attachments is enabled.
+        /// </summary>
+        [JsonProperty(PropertyName = "includeAttachments")]
+        public bool IncludeAttachments { get; set; }
+        
     }
 }


### PR DESCRIPTION
Adds config to enable including attachments when copying an instance.

## Description

See PR in [AppLibDotnet](https://github.com/Altinn/app-lib-dotnet/pull/1358).

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/1305

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to include attachments when copying instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->