### PR TITLE
Add Wolverine message bus tests

### DIFF
--- a/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/MessageboxInstancesControllerTests.cs
@@ -192,6 +192,51 @@ public class MessageBoxInstancesControllerTests(TestApplicationFactory<MessageBo
         Assert.True(actualResult);
     }
 
+    [Fact]
+    public async Task Undelete_WolverineEnabled_PublishesCommand()
+    {
+        // Arrange
+        Mock<IMessageBus> busMock = new();
+        SyncInstanceToDialogportenCommand savedCommand = null;
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .Callback<SyncInstanceToDialogportenCommand, DeliveryOptions>((cmd, _) => savedCommand = cmd)
+            .Returns(ValueTask.CompletedTask);
+
+        HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+        // Act
+        HttpResponseMessage response = await client.PutAsync($"{BasePath}/sbl/instances/1337/da1f620f-1764-4f98-9f03-74e5e20f10fe/undelete", null);
+
+        // Assert
+        busMock.VerifyAll();
+        Assert.Equal("tdd/endring-av-navn", savedCommand.AppId);
+        Assert.Equal("1337", savedCommand.PartyId);
+        Assert.Equal("da1f620f-1764-4f98-9f03-74e5e20f10fe", savedCommand.InstanceId);
+        Assert.Equal(new DateTime(2020, 04, 29).Date, savedCommand.InstanceCreatedAt.Date);
+        Assert.Equal("13:53:02.2836971", savedCommand.InstanceCreatedAt.TimeOfDay.ToString());
+        Assert.False(savedCommand.IsMigration);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Undelete_WolverineEnabledAndThrows_ReturnsOk()
+    {
+        // Arrange
+        Mock<IMessageBus> busMock = new();
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .ThrowsAsync(new Exception());
+
+        HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+        // Act
+        HttpResponseMessage response = await client.PutAsync($"{BasePath}/sbl/instances/1337/da1f620f-1764-4f98-9f03-74e5e20f10fe/undelete", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
     /// <summary>
     /// Scenario:
     ///   Restore a soft deleted instance in storage but user has too low authentication level.
@@ -309,6 +354,51 @@ public class MessageBoxInstancesControllerTests(TestApplicationFactory<MessageBo
         string content = await response.Content.ReadAsStringAsync();
         bool actualResult = JsonConvert.DeserializeObject<bool>(content);
         Assert.True(actualResult);
+    }
+
+    [Fact]
+    public async Task Delete_WolverineEnabled_PublishesCommand()
+    {
+        // Arrange
+        Mock<IMessageBus> busMock = new();
+        SyncInstanceToDialogportenCommand savedCommand = null;
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .Callback<SyncInstanceToDialogportenCommand, DeliveryOptions>((cmd, _) => savedCommand = cmd)
+            .Returns(ValueTask.CompletedTask);
+
+        HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{BasePath}/sbl/instances/1337/08274f48-8313-4e2d-9788-bbdacef5a54e?hard=false");
+
+        // Assert
+        busMock.VerifyAll();
+        Assert.Equal("tdd/endring-av-navn", savedCommand.AppId);
+        Assert.Equal("1337", savedCommand.PartyId);
+        Assert.Equal("08274f48-8313-4e2d-9788-bbdacef5a54e", savedCommand.InstanceId);
+        Assert.Equal(new DateTime(2020, 04, 29).Date, savedCommand.InstanceCreatedAt.Date);
+        Assert.Equal("13:53:02.2836971", savedCommand.InstanceCreatedAt.TimeOfDay.ToString());
+        Assert.False(savedCommand.IsMigration);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Delete_WolverineEnabledAndThrows_ReturnsOk()
+    {
+        // Arrange
+        Mock<IMessageBus> busMock = new();
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .ThrowsAsync(new Exception());
+
+        HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"{BasePath}/sbl/instances/1337/08274f48-8313-4e2d-9788-bbdacef5a54e?hard=false");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     /// <summary>
@@ -1371,12 +1461,16 @@ public class MessageBoxInstancesControllerTests(TestApplicationFactory<MessageBo
         };
     }
 
-    private HttpClient GetTestClient(Mock<IInstanceRepository> instanceRepositoryMock = null, Mock<IApplicationService> applicationServiceMock = null)
+    private HttpClient GetTestClient(
+        Mock<IInstanceRepository> instanceRepositoryMock = null,
+        Mock<IApplicationService> applicationServiceMock = null,
+        Mock<IMessageBus> messageBusMock = null,
+        bool enableWolverine = false)
     {
         // No setup required for these services. They are not in use by the MessageBoxInstancesController
         Mock<IKeyVaultClientWrapper> keyVaultWrapper = new Mock<IKeyVaultClientWrapper>();
         Mock<IPartiesWithInstancesClient> partiesWrapper = new Mock<IPartiesWithInstancesClient>();
-        Mock<IMessageBus> busMock = new Mock<IMessageBus>();
+        Mock<IMessageBus> busMock = messageBusMock ?? new Mock<IMessageBus>();
 
         HttpClient client = _factory.WithWebHostBuilder(builder =>
         {
@@ -1406,6 +1500,10 @@ public class MessageBoxInstancesControllerTests(TestApplicationFactory<MessageBo
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                 services.AddSingleton<IPublicSigningKeyProvider, PublicSigningKeyProviderMock>();
                 services.AddSingleton(busMock.Object);
+                services.Configure<WolverineSettings>(opts =>
+                {
+                    opts.EnableSending = enableWolverine;
+                });
             });
         }).CreateClient();
 

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -477,6 +477,59 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
+
+        [Fact]
+        public async Task PutInstanceAndEvents_WolverineEnabled_PublishesCommand()
+        {
+            // Arrange
+            Mock<IMessageBus> busMock = new();
+            SyncInstanceToDialogportenCommand savedCommand = null;
+            busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+                .Callback<SyncInstanceToDialogportenCommand, DeliveryOptions>((cmd, _) => savedCommand = cmd)
+                .Returns(ValueTask.CompletedTask);
+
+            HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+            ProcessStateUpdate update = new() { State = new ProcessState() };
+
+            // Act
+            using HttpResponseMessage response = await client.PutAsync(
+                "storage/api/v1/instances/1337/20b1353e-91cf-44d6-8ff7-f68993638ffe/process/instanceandevents/",
+                JsonContent.Create(update, new MediaTypeHeaderValue("application/json")));
+
+            // Assert
+            busMock.VerifyAll();
+            Assert.Equal("tdd/endring-av-navn", savedCommand.AppId);
+            Assert.Equal("1337", savedCommand.PartyId);
+            Assert.Equal("20b1353e-91cf-44d6-8ff7-f68993638ffe", savedCommand.InstanceId);
+            Assert.Equal(new DateTime(2020, 04, 29).Date, savedCommand.InstanceCreatedAt.Date);
+            Assert.Equal("13:53:02.2836971", savedCommand.InstanceCreatedAt.TimeOfDay.ToString());
+            Assert.False(savedCommand.IsMigration);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task PutInstanceAndEvents_WolverineThrows_ReturnsOk()
+        {
+            // Arrange
+            Mock<IMessageBus> busMock = new();
+            busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+                .ThrowsAsync(new Exception());
+
+            HttpClient client = GetTestClient(messageBusMock: busMock, enableWolverine: true);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(3, 1337, 3));
+
+            ProcessStateUpdate update = new() { State = new ProcessState() };
+
+            // Act
+            using HttpResponseMessage response = await client.PutAsync(
+                "storage/api/v1/instances/1337/20b1353e-91cf-44d6-8ff7-f68993638ffe/process/instanceandevents/",
+                JsonContent.Create(update, new MediaTypeHeaderValue("application/json")));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
         
         [Theory]
         [InlineData("data", new[] { "write" })]
@@ -494,12 +547,16 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             Assert.Equal(expectedActions, result);
         }
 
-        private HttpClient GetTestClient(IInstanceRepository instanceRepository = null, IInstanceAndEventsRepository instanceAndEventsRepository = null)
+        private HttpClient GetTestClient(
+            IInstanceRepository instanceRepository = null,
+            IInstanceAndEventsRepository instanceAndEventsRepository = null,
+            Mock<IMessageBus> messageBusMock = null,
+            bool enableWolverine = false)
         {
             // No setup required for these services. They are not in use by the ApplicationController
             Mock<IKeyVaultClientWrapper> keyVaultWrapper = new Mock<IKeyVaultClientWrapper>();
             Mock<IPartiesWithInstancesClient> partiesWrapper = new Mock<IPartiesWithInstancesClient>();
-            Mock<IMessageBus> busMock = new Mock<IMessageBus>();
+            Mock<IMessageBus> busMock = messageBusMock ?? new Mock<IMessageBus>();
             
             HttpClient client = _factory.WithWebHostBuilder(builder =>
             {
@@ -520,6 +577,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                     services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
                     services.AddSingleton<IInstanceEventRepository, InstanceEventRepositoryMock>();
                     services.AddSingleton(busMock.Object);
+                    services.Configure<WolverineSettings>(opts =>
+                    {
+                        opts.EnableSending = enableWolverine;
+                    });
 
                     if (instanceRepository != null)
                     {

--- a/test/UnitTest/TestingServices/InstanceEventServiceTests.cs
+++ b/test/UnitTest/TestingServices/InstanceEventServiceTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Helpers;
+using Altinn.Platform.Storage.Interface.Enums;
+using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Messages;
+using Altinn.Platform.Storage.Repository;
+using Altinn.Platform.Storage.Services;
+using Altinn.Platform.Storage.UnitTest.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Wolverine;
+using Xunit;
+
+namespace Altinn.Platform.Storage.UnitTest.TestingServices;
+
+public class InstanceEventServiceTests
+{
+    [Fact]
+    public async Task DispatchEvent_WolverineEnabled_PublishesMessage()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IInstanceEventRepository>();
+        repositoryMock.Setup(r => r.InsertInstanceEvent(It.IsAny<InstanceEvent>()))
+            .ReturnsAsync((InstanceEvent ie) => ie);
+
+        DefaultHttpContext httpContext = new() { User = PrincipalUtil.GetPrincipal(3, 1337) };
+        var contextAccessorMock = new Mock<IHttpContextAccessor>();
+        contextAccessorMock.SetupGet(a => a.HttpContext).Returns(httpContext);
+
+        var busMock = new Mock<IMessageBus>();
+        SyncInstanceToDialogportenCommand savedCommand = null;
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .Callback<SyncInstanceToDialogportenCommand, DeliveryOptions>((cmd, _) => savedCommand = cmd)
+            .Returns(ValueTask.CompletedTask);
+
+        var options = Options.Create(new WolverineSettings { EnableSending = true });
+        var loggerMock = new Mock<ILogger<InstanceEventService>>();
+
+        var service = new InstanceEventService(repositoryMock.Object, contextAccessorMock.Object, busMock.Object, options, loggerMock.Object);
+
+        Instance instance = new()
+        {
+            Id = "1337/20b1353e-91cf-44d6-8ff7-f68993638ffe",
+            AppId = "tdd/endring-av-navn",
+            InstanceOwner = new() { PartyId = "1337" },
+            Created = DateTime.Parse("2020-04-29T13:53:02.2836971Z")
+        };
+
+        // Act
+        await service.DispatchEvent(InstanceEventType.Created, instance);
+
+        // Assert
+        busMock.VerifyAll();
+        Assert.Equal("tdd/endring-av-navn", savedCommand.AppId);
+        Assert.Equal("1337", savedCommand.PartyId);
+        Assert.Equal("20b1353e-91cf-44d6-8ff7-f68993638ffe", savedCommand.InstanceId);
+        Assert.Equal(new DateTime(2020, 04, 29).Date, savedCommand.InstanceCreatedAt.Date);
+        Assert.Equal("13:53:02.2836971", savedCommand.InstanceCreatedAt.TimeOfDay.ToString());
+        Assert.False(savedCommand.IsMigration);
+    }
+
+    [Fact]
+    public async Task DispatchEvent_WolverineThrows_NoException()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IInstanceEventRepository>();
+        repositoryMock.Setup(r => r.InsertInstanceEvent(It.IsAny<InstanceEvent>()))
+            .ReturnsAsync((InstanceEvent ie) => ie);
+
+        DefaultHttpContext httpContext = new() { User = PrincipalUtil.GetPrincipal(3, 1337) };
+        var contextAccessorMock = new Mock<IHttpContextAccessor>();
+        contextAccessorMock.SetupGet(a => a.HttpContext).Returns(httpContext);
+
+        var busMock = new Mock<IMessageBus>();
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .ThrowsAsync(new Exception());
+
+        var options = Options.Create(new WolverineSettings { EnableSending = true });
+        var loggerMock = new Mock<ILogger<InstanceEventService>>();
+
+        var service = new InstanceEventService(repositoryMock.Object, contextAccessorMock.Object, busMock.Object, options, loggerMock.Object);
+
+        Instance instance = new()
+        {
+            Id = "1337/20b1353e-91cf-44d6-8ff7-f68993638ffe",
+            AppId = "tdd/endring-av-navn",
+            InstanceOwner = new() { PartyId = "1337" },
+            Created = DateTime.Parse("2020-04-29T13:53:02.2836971Z")
+        };
+
+        // Act
+        await service.DispatchEvent(InstanceEventType.Created, instance);
+
+        // Assert - no exception thrown
+    }
+
+    [Fact]
+    public async Task DispatchEvent_WithDataElement_WolverineEnabled_PublishesMessage()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IInstanceEventRepository>();
+        repositoryMock.Setup(r => r.InsertInstanceEvent(It.IsAny<InstanceEvent>()))
+            .ReturnsAsync((InstanceEvent ie) => ie);
+
+        DefaultHttpContext httpContext = new() { User = PrincipalUtil.GetPrincipal(3, 1337) };
+        var contextAccessorMock = new Mock<IHttpContextAccessor>();
+        contextAccessorMock.SetupGet(a => a.HttpContext).Returns(httpContext);
+
+        var busMock = new Mock<IMessageBus>();
+        SyncInstanceToDialogportenCommand savedCommand = null;
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .Callback<SyncInstanceToDialogportenCommand, DeliveryOptions>((cmd, _) => savedCommand = cmd)
+            .Returns(ValueTask.CompletedTask);
+
+        var options = Options.Create(new WolverineSettings { EnableSending = true });
+        var loggerMock = new Mock<ILogger<InstanceEventService>>();
+
+        var service = new InstanceEventService(repositoryMock.Object, contextAccessorMock.Object, busMock.Object, options, loggerMock.Object);
+
+        Instance instance = new()
+        {
+            Id = "1337/20b1353e-91cf-44d6-8ff7-f68993638ffe",
+            AppId = "tdd/endring-av-navn",
+            InstanceOwner = new() { PartyId = "1337" },
+            Created = DateTime.Parse("2020-04-29T13:53:02.2836971Z")
+        };
+        DataElement dataElement = new() { Id = "data" };
+
+        // Act
+        await service.DispatchEvent(InstanceEventType.Saved, instance, dataElement);
+
+        // Assert
+        busMock.VerifyAll();
+        Assert.Equal("tdd/endring-av-navn", savedCommand.AppId);
+        Assert.Equal("1337", savedCommand.PartyId);
+        Assert.Equal("20b1353e-91cf-44d6-8ff7-f68993638ffe", savedCommand.InstanceId);
+        Assert.Equal(new DateTime(2020, 04, 29).Date, savedCommand.InstanceCreatedAt.Date);
+        Assert.Equal("13:53:02.2836971", savedCommand.InstanceCreatedAt.TimeOfDay.ToString());
+        Assert.False(savedCommand.IsMigration);
+    }
+
+    [Fact]
+    public async Task DispatchEvent_WithDataElement_WolverineThrows_NoException()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IInstanceEventRepository>();
+        repositoryMock.Setup(r => r.InsertInstanceEvent(It.IsAny<InstanceEvent>()))
+            .ReturnsAsync((InstanceEvent ie) => ie);
+
+        DefaultHttpContext httpContext = new() { User = PrincipalUtil.GetPrincipal(3, 1337) };
+        var contextAccessorMock = new Mock<IHttpContextAccessor>();
+        contextAccessorMock.SetupGet(a => a.HttpContext).Returns(httpContext);
+
+        var busMock = new Mock<IMessageBus>();
+        busMock.Setup(b => b.PublishAsync(It.IsAny<SyncInstanceToDialogportenCommand>(), null))
+            .ThrowsAsync(new Exception());
+
+        var options = Options.Create(new WolverineSettings { EnableSending = true });
+        var loggerMock = new Mock<ILogger<InstanceEventService>>();
+
+        var service = new InstanceEventService(repositoryMock.Object, contextAccessorMock.Object, busMock.Object, options, loggerMock.Object);
+
+        Instance instance = new()
+        {
+            Id = "1337/20b1353e-91cf-44d6-8ff7-f68993638ffe",
+            AppId = "tdd/endring-av-navn",
+            InstanceOwner = new() { PartyId = "1337" },
+            Created = DateTime.Parse("2020-04-29T13:53:02.2836971Z")
+        };
+        DataElement dataElement = new() { Id = "data" };
+
+        // Act
+        await service.DispatchEvent(InstanceEventType.Saved, instance, dataElement);
+
+        // Assert - no exception thrown
+    }
+}


### PR DESCRIPTION
## Summary
- cover InstanceEventService message publication
- verify message bus integration for MessageBoxInstancesController
- add Wolverine invocation tests for ProcessController

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863cac752c08326a5dc33155ebc7dc9