### PR TITLE
Workflow for PR builds/experimental packages for Altinn.Platform.Storage.Interface

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,0 +1,85 @@
+name: PR actions
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  publish:
+    name: Publish PR packages
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: |
+            9.0.x
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/pull/{0}/head', github.event.issue.number) }}
+          fetch-depth: 0
+
+      - name: Build PR release version
+        id: build-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid | jq -r '.headRefOid' | cut -c1-8)
+          branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName | jq -r '.headRefName' | sed 's/.*\///')
+          version=$(git describe --abbrev=0 --tags 2>/dev/null)
+          version=$(echo $version | cut -d '-' -f 2)
+          version="$version-pr.${{ github.run_number }}.$branch.$sha"
+          version=$(echo $version | sed 's/^v//')
+          echo "MINVERVERSIONOVERRIDE=$version" >> $GITHUB_ENV
+          echo "PR_RELEASE_VERSION=$version" >> $GITHUB_OUTPUT
+          echo $version
+
+      - name: Create PR comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        id: pr-comment
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ## PR release:
+
+            * [Altinn.Platform.Storage.Interface ${{ steps.build-version.outputs.PR_RELEASE_VERSION }}](https://www.nuget.org/packages/Altinn.Platform.Storage.Interface.Experimental/${{ steps.build-version.outputs.PR_RELEASE_VERSION }})
+
+            > ⚙️ Building...
+
+      - name: Install deps
+        run: |
+          cd src/Storage.Interface
+          dotnet restore
+      - name: Build
+        run: |
+          cd src/Storage.Interface
+          dotnet build --configuration Release --no-restore -p:Deterministic=true -p:BuildNumber=${{ github.run_number }}
+      - name: Pack PR release
+        run: |
+          cd src/Storage.Interface
+          dotnet pack --configuration Release --no-restore --no-build -p:BuildNumber=${{ github.run_number }} -p:Deterministic=true
+      - name: Publish PR release
+        run: |
+          cd src/Storage.Interface
+          dotnet nuget push bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+
+      - name: Update PR comment - failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        if: failure()
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ steps.pr-comment.outputs.comment-id }}
+          edit-mode: append
+          body: |
+            > ❌ Failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Update PR comment - success
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        if: success()
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ steps.pr-comment.outputs.comment-id }}
+          edit-mode: append
+          body: |
+            > ✅ Done!
+          reactions: rocket

--- a/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
+++ b/src/Storage.Interface/Altinn.Platform.Storage.Interface.csproj
@@ -20,6 +20,10 @@
     <ProjectGuid>{D9F6DAB7-E921-44B6-A1A6-5796DCAE0D07}</ProjectGuid>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MinVerVersionOverride)'!=''">
+    <PackageId>$(MSBuildProjectName).Experimental</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="9.0.6" />


### PR DESCRIPTION
## Description

We have an urgent case we are working on and would like to speed up development by enabling us to publish unmerged experimental packages that we can use for example in app-localtest during PoC building and such. This PR adds a workflow that responds to `/publish` comments in PR by

* Making a comment with package information, notifying that it is currently building
* Builds, packs and publishes Altinn.Platform.Storage.Interface
* Updates the previous comment with a "done" notification

Example run through the version building step: 

![image](https://github.com/user-attachments/assets/c7a57c4a-d815-45c1-b0ff-1ce80c11696c)

Package ID becomes: `Altinn.Platform.Storage.Interface.Experimental`
To avoid polluting the version list for the actual package.

We support this in app-lib currently, example workflow: https://github.com/Altinn/app-lib-dotnet/pull/1357#issuecomment-2997894089

I can't test this workflow before merging, since issue_comment workflows only run from main, so there might be some churn here

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
