### PR TITLE
Add ActionRequiredToRead and ActionRequiredToWrite to data type.

### DIFF
--- a/src/Storage.Interface/Models/DataType.cs
+++ b/src/Storage.Interface/Models/DataType.cs
@@ -50,6 +50,18 @@ namespace Altinn.Platform.Storage.Interface.Models
         /// </summary>
         [JsonProperty(PropertyName = "allowedContributors")]
         public List<string> AllowedContributors { get; set; }
+        
+        /// <summary>
+        /// When this is set, it overrides what action is required to read the blob of data elements of this data type.
+        /// </summary>
+        [JsonProperty(PropertyName = "actionRequiredToRead")]
+        public string ActionRequiredToRead { get; set; }
+        
+        /// <summary>
+        /// When this is set, it overrides what action is required to write to the blob of data elements of this data type.
+        /// </summary>
+        [JsonProperty(PropertyName = "actionRequiredToWrite")]
+        public string ActionRequiredToWrite { get; set; }
 
         /// <summary>
         /// Gets or sets an object with information about how the application logic will handle the data element.


### PR DESCRIPTION
## Description
This PR adds the following properties to the `DataType` model:
- ActionRequiredToRead
- ActionRequiredToWrite

These props may be used by app developers to specify custom authorisation actions that are required in order to read from and write to the affected data types.

An example of usage can be seen here: [applicationmedata.json](https://altinn.studio/repos/ttd/sensitive-data/src/branch/master/App/config/applicationmetadata.json#L66-L67) + [policy.xml](https://altinn.studio/repos/ttd/sensitive-data/src/branch/master/App/config/authorization/policy.xml#L101-L112).

Proposed implementation in LocalTest: https://github.com/Altinn/app-localtest/pull/163

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/1376

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new fields to display the actions required to read from or write to specific data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->