### PR TITLE
Add authorization case for pdf and eFormilding service tasks.

### DIFF
--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -331,7 +331,7 @@ namespace Altinn.Platform.Storage.Controllers
             return taskType switch
             {
                 null => [],
-                "data" or "feedback" => ["write"],
+                "data" or "feedback" or "pdf" or "eFormidling" => ["write"],
                 "payment" => ["pay", "write"],
                 "confirmation" => ["confirm"],
                 "signing" => ["sign", "write"],

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -554,6 +554,8 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
         [Theory]
         [InlineData("data", new[] { "write" })]
         [InlineData("feedback", new[] { "write" })]
+        [InlineData("pdf", new[] { "write" })]
+        [InlineData("eFormidling", new[] { "write" })]
         [InlineData("payment", new[] { "pay", "write" })]
         [InlineData("confirmation", new[] { "confirm" })]
         [InlineData("signing", new[] { "sign", "write" })]


### PR DESCRIPTION
Add authorization case for pdf and eFormilding service tasks.

Previously PDF and eFormidling were not their own type of task in BPMN, but just inline process next code. Now we will support adding them as service tasks, and then we need to add these cases so that they are still authorized as 'write', which they were indirectly authorized as before, as part of the EndTaskEventHandler for the data task.

PR for service task feature in app-lib: https://github.com/Altinn/app-lib-dotnet/pull/745

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/368

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
