### PR TITLE
Fix nullability of get instance events query params

### DIFF
--- a/src/Storage/Controllers/InstanceEventsController.cs
+++ b/src/Storage/Controllers/InstanceEventsController.cs
@@ -150,8 +150,8 @@ namespace Altinn.Platform.Storage.Controllers
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
             [FromQuery] string[] eventTypes,
-            [FromQuery] string from,
-            [FromQuery] string to)
+            [FromQuery] string? from,
+            [FromQuery] string? to)
         {
             string instanceId = $"{instanceOwnerPartyId}/{instanceGuid}";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding `#nullable enable` made query params `to` and `from` required, resulting in the following response:
```json
{
    "errors": {
        "to": [
            "The to field is required."
        ],
        "from": [
            "The from field is required."
        ]
    },
    "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
    "title": "One or more validation errors occurred.",
    "status": 400,
    "traceId": "00-fa628f144907fc29905c79b94d3e57e8-2b6f17911034f1b1-01"
}
```

## Related Issue(s)
- https://github.com/Altinn/altinn-storage/pull/736

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
