### PR TITLE
Fix flakyness related to telemetry testing

### DIFF
--- a/test/UnitTest/TestingControllers/DataControllerTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerTests.cs
@@ -80,7 +80,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             HttpResponseMessage response = await client.PostAsync($"{dataPathWithData}?dataType=default", content);
 
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-            Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+            await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
         }
 
         [Fact]
@@ -294,7 +294,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             HttpResponseMessage response = await client.GetAsync($"{dataPathWithData}");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+            await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
         }
 
         [Fact]

--- a/test/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -97,7 +97,7 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
         string responseContent = await response.Content.ReadAsStringAsync();
         Instance instance = (Instance)JsonConvert.DeserializeObject(responseContent, typeof(Instance));
         Assert.Equal("1337", instance.InstanceOwner.PartyId);
-        Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+        await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
     }
 
     [Fact]
@@ -280,7 +280,7 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
         string json = await response.Content.ReadAsStringAsync();
         Instance createdInstance = JsonConvert.DeserializeObject<Instance>(json);
         Assert.NotNull(createdInstance);
-        Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+        await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
     }
 
     [Theory]
@@ -309,7 +309,7 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
         string json = await response.Content.ReadAsStringAsync();
         Instance createdInstance = JsonConvert.DeserializeObject<Instance>(json);
         Assert.NotNull(createdInstance);
-        Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+        await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
     }
 
     /// <summary>
@@ -696,7 +696,7 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
             Assert.Equal(expectedNoInstances, queryResponse.Count);
         }
 
-        Assert.Equal(invalidScopeRequests, _testTelemetry.RequestsWithInvalidScopesCount());
+        await _testTelemetry.AssertRequestsWithInvalidScopesCountAsync(invalidScopeRequests);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Fixes the flakyness by moving the asserts into `TestTelemetry` and retrying in a loop for a maximum of 100ms

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of tests by updating assertions for invalid scope request counts to use an asynchronous method with retry logic.
  * Enhanced test methods to await asynchronous assertions, ensuring more robust metric validation during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->