### PR TITLE
Performance tuning of storage authorization service

### DIFF
--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -4,17 +4,15 @@ using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
-
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
-
 using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
-
+using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
-
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.Platform.Storage.Authorization;
 
@@ -27,14 +25,17 @@ namespace Altinn.Platform.Storage.Authorization;
 /// <param name="pdp">Policy decision point</param>
 /// <param name="claimsPrincipalProvider">A service providing access to the current <see cref="ClaimsPrincipal"/>.</param>
 /// <param name="logger">The logger</param>
+/// <param name="settings">General configuration settings</param>
 public class AuthorizationService(
     IPDP pdp, 
     IClaimsPrincipalProvider claimsPrincipalProvider, 
-    ILogger<AuthorizationService> logger) : IAuthorization
+    ILogger<AuthorizationService> logger,
+    IOptions<GeneralSettings> settings) : IAuthorization
 {
     private readonly IPDP _pdp = pdp;
     private readonly IClaimsPrincipalProvider _claimsPrincipalProvider = claimsPrincipalProvider;
     private readonly ILogger<AuthorizationService> _logger = logger;
+    private readonly GeneralSettings _settings = settings.Value;
 
     private const string XacmlResourceTaskId = "urn:altinn:task";
     private const string XacmlResourceEndId = "urn:altinn:end-event";
@@ -46,22 +47,32 @@ public class AuthorizationService(
     private const string ResourceId = "r";
 
     /// <inheritdoc/>>
-    public async Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances, bool includeInstantiate)
+    public async Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances, bool keyAccessMode)
     {
         if (instances.Count <= 0)
         {
             return [];
         }
 
-        List<MessageBoxInstance> authorizedInstanceList = [];
-        List<string> actionTypes = ["read", "write", "delete"];
+        SortedList<string, MessageBoxInstance> authorizedInstanceList = [];
+        List<string> actionTypes = ["read"];
+        if (_settings.AuthorizeA2ListInstancesWrite || keyAccessMode)
+        {
+            actionTypes.Add("write");
+        }
 
-        if (includeInstantiate)
+        if (_settings.AuthorizeA2ListInstancesDelete || keyAccessMode)
+        {
+            actionTypes.Add("delete");
+        }
+
+        if (keyAccessMode)
         {
             actionTypes.Add("instantiate");
         }
 
-        if (instances.Exists(i => "Signing".Equals(i.Process?.CurrentTask?.AltinnTaskType.ToString(), StringComparison.InvariantCultureIgnoreCase)))
+        if ((_settings.AuthorizeA2ListInstancesSign || keyAccessMode)
+            && instances.Exists(i => "Signing".Equals(i.Process?.CurrentTask?.AltinnTaskType.ToString(), StringComparison.InvariantCultureIgnoreCase)))
         {
             actionTypes.Add("sign");
         }
@@ -95,12 +106,11 @@ public class AuthorizationService(
 
                 Instance authorizedInstance = instances.First(i => i.Id == instanceId);
 
-                MessageBoxInstance authorizedMessageBoxInstance =
-                    authorizedInstanceList.Find(i => i.Id.Equals(authorizedInstance.Id.Split("/")[1]));
-                if (authorizedMessageBoxInstance is null)
+                string id = authorizedInstance.Id.Split("/")[1];
+                if (!authorizedInstanceList.TryGetValue(id, out MessageBoxInstance authorizedMessageBoxInstance))
                 {
                     authorizedMessageBoxInstance = InstanceHelper.ConvertToMessageBoxInstance(authorizedInstance);
-                    authorizedInstanceList.Add(authorizedMessageBoxInstance);
+                    authorizedInstanceList[id] = authorizedMessageBoxInstance;
                 }
 
                 switch (actiontype)
@@ -123,7 +133,7 @@ public class AuthorizationService(
             }
         }
 
-        return authorizedInstanceList;
+        return authorizedInstanceList.Values.ToList();
     }
 
     /// <inheritdoc/>>

--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -72,7 +72,7 @@ public class AuthorizationService(
         }
 
         if ((_settings.AuthorizeA2ListInstancesSign || keyAccessMode)
-            && instances.Exists(i => "Signing".Equals(i.Process?.CurrentTask?.AltinnTaskType.ToString(), StringComparison.InvariantCultureIgnoreCase)))
+            && instances.Exists(i => "Signing".Equals(i.Process?.CurrentTask?.AltinnTaskType?.ToString(), StringComparison.InvariantCultureIgnoreCase)))
         {
             actionTypes.Add("sign");
         }

--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -16,7 +16,7 @@ namespace Altinn.Platform.Storage.Authorization
         /// <summary>
         /// Authorize instances, and returns a list of MesseageBoxInstances with information about read and write rights of each instance.
         /// </summary>
-        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances, bool includeInstantiate);
+        public Task<List<MessageBoxInstance>> AuthorizeMesseageBoxInstances(List<Instance> instances, bool keyAccessMode);
 
         /// <summary>
         /// Authorizes a given action on an instance.

--- a/src/Storage/Configuration/GeneralSettings.cs
+++ b/src/Storage/Configuration/GeneralSettings.cs
@@ -78,5 +78,20 @@ namespace Altinn.Platform.Storage.Configuration
         /// be set to false on demand by manipulating the aks yaml config in the target environment.
         /// </summary>
         public bool DisableTelemetryForMigration { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to use write as an action when authorizing A2 search requests.
+        /// </summary>
+        public bool AuthorizeA2ListInstancesWrite { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets whether to use delete as an action when authorizing A2 search requests.
+        /// </summary>
+        public bool AuthorizeA2ListInstancesDelete { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to use sign as an action when authorizing A2 search requests.
+        /// </summary>
+        public bool AuthorizeA2ListInstancesSign { get; set; } = true;
     }
 }

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -3,21 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Authorization;
+using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.UnitTest.Mocks;
-
 using AltinnCore.Authentication.Constants;
-
 using Microsoft.Extensions.Logging;
-
+using Microsoft.Extensions.Options;
 using Moq;
-
 using Xunit;
 
 namespace Altinn.Platform.Storage.UnitTest.TestingServices
@@ -40,8 +37,10 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
         {
             _pdpSimpleMock = new Mock<IPDP>();
             _pdpMockSI = new PepWithPDPAuthorizationMockSI(_instanceRepository.Object);
+            var generalSettings = new GeneralSettings { AuthorizeA2ListInstancesDelete = true };
+            var options = Options.Create(generalSettings);
             _authzService = new AuthorizationService(
-                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>());
+                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
         }
 
         [Fact]
@@ -61,8 +60,11 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             _pdpSimpleMock.Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
                 .ReturnsAsync(res);
 
+            var generalSettings = new GeneralSettings { AuthorizeA2ListInstancesDelete = true };
+            var options = Options.Create(generalSettings);
+
             var sut = new AuthorizationService(
-                _pdpSimpleMock.Object, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>());
+                _pdpSimpleMock.Object, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
             await sut.GetDecisionForRequest(new XacmlJsonRequestRoot());
 
             _pdpSimpleMock.Verify(m => m.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()), Times.Once());
@@ -256,6 +258,52 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Assert.Equal(expected, actual);
         }
 
+        /// <summary>
+        /// Test case: Authorize a list of instances to messageboxInstances
+        /// Expected: Delete and write is not allowed, so the AllowDelete and AuthorizedForWrite properties are false.
+        /// </summary>
+        [Fact]
+        public async Task AuthorizeMesseageBoxInstances_TC02_ListWithDeleteAndWriteTrue()
+        {
+            // Arrange
+            List<Instance> instances = CreateInstances();
+            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
+            var options = Options.Create(new GeneralSettings { AuthorizeA2ListInstancesDelete = true, AuthorizeA2ListInstancesWrite = true });
+            var authzService = new AuthorizationService(
+                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
+
+            // Act
+            List<MessageBoxInstance> actual = await authzService.AuthorizeMesseageBoxInstances(instances, false);
+
+            // Assert
+            Assert.Equal(3, actual.Count);
+            Assert.True(actual[0].AllowDelete);
+            Assert.True(actual[0].AuthorizedForWrite);
+        }
+
+        /// <summary>
+        /// Test case: Authorize a list of instances to messageboxInstances
+        /// Expected: Delete and write is not allowed, so the AllowDelete and AuthorizedForWrite properties are false.
+        /// </summary>
+        [Fact]
+        public async Task AuthorizeMesseageBoxInstances_TC03_ListWithDeleteAndWriteFalse()
+        {
+            // Arrange
+            List<Instance> instances = CreateInstances();
+            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
+            var options = Options.Create(new GeneralSettings { AuthorizeA2ListInstancesDelete = false, AuthorizeA2ListInstancesWrite = false });
+            var authzService = new AuthorizationService(
+                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
+
+            // Act
+            List<MessageBoxInstance> actual = await authzService.AuthorizeMesseageBoxInstances(instances, false);
+
+            // Assert
+            Assert.Equal(3, actual.Count);
+            Assert.False(actual[0].AllowDelete);
+            Assert.False(actual[0].AuthorizedForWrite);
+        }
+
         private static ClaimsPrincipal CreateUserClaims(int userId)
         {
             // Create the user
@@ -278,7 +326,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             {
                 new Instance
                 {
-                    Id = "1000/1",
+                    Id = "1000/" + Guid.NewGuid(),
                     Process = new ProcessState
                     {
                         CurrentTask = new ProcessElementInfo
@@ -291,27 +339,30 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
                         PartyId = "1000"
                     },
                     AppId = Org + "/" + App,
-                    Org = Org
+                    Org = Org,
+                    Created = DateTime.UtcNow
                 },
                 new Instance
                 {
-                    Id = "1002/4",
+                    Id = "1002/" + Guid.NewGuid(),
                     InstanceOwner = new InstanceOwner
                     {
                         PartyId = "1002"
                     },
                     AppId = Org + "/" + App,
-                    Org = Org
+                    Org = Org,
+                    Created = DateTime.UtcNow
                 },
                 new Instance
                 {
-                    Id = "1000/7",
+                    Id = "1000/" + Guid.NewGuid(),
                     InstanceOwner = new InstanceOwner
                     {
                         PartyId = "1000"
                     },
                     AppId = Org + "/" + App,
-                    Org = Org
+                    Org = Org,
+                    Created = DateTime.UtcNow
                 }
             };
 

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -258,52 +258,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices
             Assert.Equal(expected, actual);
         }
 
-        /// <summary>
-        /// Test case: Authorize a list of instances to messageboxInstances
-        /// Expected: Delete and write is not allowed, so the AllowDelete and AuthorizedForWrite properties are false.
-        /// </summary>
-        [Fact]
-        public async Task AuthorizeMesseageBoxInstances_TC02_ListWithDeleteAndWriteTrue()
-        {
-            // Arrange
-            List<Instance> instances = CreateInstances();
-            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
-            var options = Options.Create(new GeneralSettings { AuthorizeA2ListInstancesDelete = true, AuthorizeA2ListInstancesWrite = true });
-            var authzService = new AuthorizationService(
-                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
-
-            // Act
-            List<MessageBoxInstance> actual = await authzService.AuthorizeMesseageBoxInstances(instances, false);
-
-            // Assert
-            Assert.Equal(3, actual.Count);
-            Assert.True(actual[0].AllowDelete);
-            Assert.True(actual[0].AuthorizedForWrite);
-        }
-
-        /// <summary>
-        /// Test case: Authorize a list of instances to messageboxInstances
-        /// Expected: Delete and write is not allowed, so the AllowDelete and AuthorizedForWrite properties are false.
-        /// </summary>
-        [Fact]
-        public async Task AuthorizeMesseageBoxInstances_TC03_ListWithDeleteAndWriteFalse()
-        {
-            // Arrange
-            List<Instance> instances = CreateInstances();
-            _claimsPrincipalProviderMock.Setup(c => c.GetUser()).Returns(CreateUserClaims(3));
-            var options = Options.Create(new GeneralSettings { AuthorizeA2ListInstancesDelete = false, AuthorizeA2ListInstancesWrite = false });
-            var authzService = new AuthorizationService(
-                _pdpMockSI, _claimsPrincipalProviderMock.Object, Mock.Of<ILogger<AuthorizationService>>(), options);
-
-            // Act
-            List<MessageBoxInstance> actual = await authzService.AuthorizeMesseageBoxInstances(instances, false);
-
-            // Assert
-            Assert.Equal(3, actual.Count);
-            Assert.False(actual[0].AllowDelete);
-            Assert.False(actual[0].AuthorizedForWrite);
-        }
-
         private static ClaimsPrincipal CreateUserClaims(int userId)
         {
             // Create the user

--- a/test/UnitTest/appsettings.unittest.json
+++ b/test/UnitTest/appsettings.unittest.json
@@ -21,7 +21,10 @@
     "InstanceSyncAdapterScope": "altinn:storage/instances.syncadapter",
     "AppTitleCacheLifeTimeInSeconds": 60,
     "AppMetadataCacheLifeTimeInSeconds": 60,
-    "TextResourceCacheLifeTimeInSeconds": 60
+    "TextResourceCacheLifeTimeInSeconds": 60,
+    "AuthorizeA2ListInstancesWrite":  true,
+    "AuthorizeA2ListInstancesDelete":  true,
+    "AuthorizeA2ListInstancesSign":  true
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/"


### PR DESCRIPTION
## Description
- Configurable whether to authorize sign, write and delete for a2 msg box search. The default is to suppress write.
- Use sorted list to look up authorized instances (much better performance for large lists)

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options to control authorization for write, delete, and sign actions during A2 search requests.
  * Updated authorization to dynamically adjust permitted actions based on settings and access mode.

* **Bug Fixes**
  * Improved authorization logic to better reflect configurable permissions.

* **Tests**
  * Enhanced unit tests to validate authorization behavior under various configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->