### PR TITLE
Error PR actions workflow when run by non-contributor

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -8,6 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
     steps:
+      - name: Check if comment author is a contributor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          comment_author="${{ github.event.comment.user.login }}"
+          if gh api repos/${{ github.repository }}/collaborators/$comment_author --silent; then
+            echo "Comment author ($comment_author) is a contributor, continuing"
+          else
+            echo "Comment author ($comment_author) is not a contributor, skipping job"
+            exit 1
+          fi
+
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -13,10 +13,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           comment_author="${{ github.event.comment.user.login }}"
-          if gh api repos/${{ github.repository }}/collaborators/$comment_author --silent; then
-            echo "Comment author ($comment_author) is a contributor, continuing"
+
+          # Check if user has write access using a different approach
+          permission=$(gh api repos/${{ github.repository }}/collaborators/$comment_author/permission 2>/dev/null | jq -r '.permission // "none"')
+          if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+            echo "Comment author ($comment_author) has $permission access, continuing"
           else
-            echo "Comment author ($comment_author) is not a contributor, skipping job"
+            echo "Comment author ($comment_author) has $permission access, skipping job"
             exit 1
           fi
 


### PR DESCRIPTION
## Description
Error PR actions workflow when run by non-contributor

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an authorization check to ensure only collaborators with admin or write access can trigger the publish workflow. Requests from users without these permissions are automatically skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->