### PR TITLE
incorrect URI submitted in appsettings, now fixed

### DIFF
--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -19,7 +19,7 @@
     "Hostname": "at22.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "BridgeApiAuthorizationEndpoint": "http://localhost:5055/sblbridge/authorization/api/",
-    "BridgeApiCorrespondenceEndpoint": "http://localhost:5055/sblbridge/correspondence/api/",
+    "BridgeApiCorrespondenceEndpoint": "http://localhost:5055/sblbridge/serviceengine/api/",
     "OndemandEndpoint": "http://localhost:5010/storage/api/v1/",
     "PdfGeneratorEndpoint": "http://localhost:5050/pdf-generator.pdf-generator",
     "TextResourceCacheLifeTimeInSeconds": 3600,

--- a/test/UnitTest/TestingControllers/SblBridgeControllerTests.cs
+++ b/test/UnitTest/TestingControllers/SblBridgeControllerTests.cs
@@ -45,7 +45,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             {
                 partyId = 1337
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         }
 
@@ -60,7 +59,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
             {
                 partyId = 0
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);           
         }
 
@@ -79,7 +77,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 eventTimeStamp = dateTimeOffset,
                 eventType = "read"
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
         }
 
@@ -98,7 +95,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 eventTimeStamp = dateTimeOffset,
                 eventType = "read"
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
         }
 
@@ -117,7 +113,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 eventTimeStamp = dateTimeOffset,
                 eventType = "read"
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
         }
 
@@ -136,7 +131,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 eventTimeStamp = dateTimeOffset,
                 eventType = "invalidRead"
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
         }
 
@@ -155,7 +149,6 @@ namespace Altinn.Platform.Storage.UnitTest.TestingControllers
                 eventTimeStamp = dateTimeOffset,
                 eventType = "read"
             }));
-            var body = await response.Content.ReadAsStringAsync();
             Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
         }
         

--- a/test/UnitTest/appsettings.unittest.json
+++ b/test/UnitTest/appsettings.unittest.json
@@ -17,7 +17,7 @@
     "Hostname": "at22.altinn.cloud",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "BridgeApiAuthorizationEndpoint": "http://localhost:5055/sblbridge/authorization/api/",
-    "BridgeApiCorrespondenceEndpoint": "http://localhost:5055/sblbridge/correspondence/api/",
+    "BridgeApiCorrespondenceEndpoint": "http://localhost:5055/sblbridge/serviceengine/api/",
     "InstanceReadScope": [ "altinn:serviceowner/instances.read" ],
     "InstanceSyncAdapterScope": "altinn:storage/instances.syncadapter",
     "AppTitleCacheLifeTimeInSeconds": 60,


### PR DESCRIPTION
I'd previously submitted the incorrect uri in appsettings. This is now fixed.


## Related Issue(s)
- #1177

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Updated application configuration to use the ServiceEngine API endpoint for bridge operations.

- Tests
  - Simplified unit tests by removing unnecessary response body reads while retaining status code assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->