### PR TITLE
Final brushes on codeql action addition

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,6 @@ on:
       - '.github/workflows/**'
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
       - '.github/workflows/**'
@@ -27,12 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['csharp', 'actions']
-
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: autobuild
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Setup .NET
+      - name: Setup .NET 9.0.* SDK
+        if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
         with:
           dotnet-version: |
@@ -41,12 +44,11 @@ jobs:
         uses: github/codeql-action/init@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8


### PR DESCRIPTION
## Description
- Formats the YAML doc
- Runs .NET setup action only when language is 'csharp', skipping it when language is 'actions' (i.e. GH workflows / yaml code)
- Replaces the old Autobuild step with `build-mode` parameter to the `init` action
## Related Issue(s)
- [#355](https://github.com/Altinn/team-core-private/issues/345?issue=Altinn%7Cteam-core-private%7C355)(team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CodeQL security scanning to include C# language analysis.
  * Configured .NET SDK setup within the CI/CD pipeline for automated builds.
  * Restructured workflow matrix strategy to support multiple programming languages more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->