### PR TITLE
Improve handling of invalid text resource

### DIFF
--- a/src/Storage/Helpers/InstanceHelper.cs
+++ b/src/Storage/Helpers/InstanceHelper.cs
@@ -184,8 +184,8 @@ namespace Altinn.Platform.Storage.Helpers
             {
                 string id = $"{instance.Org}-{instance.AppName}-{language}";
                 string appTitle =
-                    textResources.Find(t => t.Id.Equals(id))?.Resources.Where(r => r.Id.Equals("appName")).Select(r => r.Value).FirstOrDefault() ??
-                    textResources.Find(t => t.Id.Equals(id))?.Resources.Where(r => r.Id.Equals("ServiceName")).Select(r => r.Value).FirstOrDefault();
+                    textResources.Find(t => t.Id.Equals(id))?.Resources.Where(r => r.Id != null && r.Id.Equals("appName")).Select(r => r.Value).FirstOrDefault() ??
+                    textResources.Find(t => t.Id.Equals(id))?.Resources.Where(r => r.Id != null && r.Id.Equals("ServiceName")).Select(r => r.Value).FirstOrDefault();
                 instance.Title = appTitle ?? instance.AppName;
 
                 if (!string.IsNullOrWhiteSpace(instance.PresentationText))

--- a/test/UnitTest/HelperTests/InstanceHelperTest.cs
+++ b/test/UnitTest/HelperTests/InstanceHelperTest.cs
@@ -540,6 +540,50 @@ namespace Altinn.Platform.Storage.UnitTest
             Assert.Equal("test.event", actual.EventType);
         }
 
+        /// <summary>
+        /// Replaces text keys, appName key is available, should be used as Title
+        /// </summary>
+        [Fact]
+        public void ReplaceTextKeys_EmptyResourceEntry_HandledGracefully()
+        {
+            // Arrange
+            List<MessageBoxInstance> instances =
+            [
+                new MessageBoxInstance
+                {
+                    Org = "ttd",
+                    AppName = "test-app"
+                },
+            ];
+
+            List<TextResource> textResources = [];
+            List<TextResourceElement> textResource =
+            [
+                new TextResourceElement
+                {
+                    Id = null,
+                    Value = null,
+                },
+                new TextResourceElement
+                {
+                    Id = "appName",
+                    Value = "ValueFromAppNameKey",
+                },
+            ];
+
+            textResources.Add(new TextResource
+            {
+                Id = "ttd-test-app-nb",
+                Resources = textResource
+            });
+
+            // Act
+            instances = InstanceHelper.ReplaceTextKeys(instances, textResources, "nb");
+
+            // Assert
+            Assert.Equal("ValueFromAppNameKey", instances[0].Title);
+        }
+
         [Theory]
         [InlineData(null, "", "")]
         [InlineData("", "", "")]


### PR DESCRIPTION
## Description
Improve handling of an edge case where one or more resources in a text resource is empty. 

## Related Issue(s)
- #831

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null reference exception when processing empty text resource entries, ensuring graceful handling when fallback values are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->