### PR TITLE
Skip the job 'Publish PR packages' if coderabbitai is comment author

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -6,10 +6,9 @@ on:
   
 jobs: 
   publish:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish') && github.event.comment.user.login != 'coderabbitai[bot]'
     name: Publish PR packages
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/publish') && github.event.comment.user.login != 'coderabbitai[bot]'
     permissions:
       contents: read         
     steps:


### PR DESCRIPTION
## Description
Working on a separate issue, in PR #850, the pr-actions workflow is creating unnecessary noise in the PR due to the workflow triggering on the comments of CodeRabbit. 

This PR extends the job with an additional condition to prevent it from running for coderabbit's comments

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow: the publish job now only runs when a PR comment contains "/publish" and the comment author is not an automated bot, adding an extra validation to control publish operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->