### PR TITLE
Remove dependency on fluentassertions

### DIFF
--- a/test/Altinn.Platform.Storage.Interface.Tests/AllowAnonymousOnStateless/ApplicationTests.cs
+++ b/test/Altinn.Platform.Storage.Interface.Tests/AllowAnonymousOnStateless/ApplicationTests.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Altinn.Platform.Storage.Interface.Models;
-using FluentAssertions;
 using Xunit;
 
 namespace Altinn.Platform.Storage.Interface.Tests;
@@ -15,10 +14,11 @@ public class ApplicationTests
                 "AllowAnonymousOnStateless.applicationMetadata_beforeChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.AllowAnonymousOnStateless.Should()
-            .BeFalse();
+        Assert.False(
+            applicationBefore
+                .DataTypes.First(d => d.Id == "Veileder")
+                .AppLogic.AllowAnonymousOnStateless
+        );
     }
 
     [Fact]
@@ -29,9 +29,10 @@ public class ApplicationTests
                 "AllowAnonymousOnStateless.applicationMetadata_afterChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.AllowAnonymousOnStateless.Should()
-            .BeTrue();
+        Assert.True(
+            applicationBefore
+                .DataTypes.First(d => d.Id == "Veileder")
+                .AppLogic.AllowAnonymousOnStateless
+        );
     }
 }

--- a/test/Altinn.Platform.Storage.Interface.Tests/AllowUserActions/AllowUserActions.cs
+++ b/test/Altinn.Platform.Storage.Interface.Tests/AllowUserActions/AllowUserActions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Altinn.Platform.Storage.Interface.Models;
-using FluentAssertions;
 using Xunit;
 
 namespace Altinn.Platform.Storage.Interface.Tests.AllowUserActions;
@@ -15,14 +14,12 @@ public class AllowUserActions
                 "AllowUserActions.applicationMetadata_beforeChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.DisallowUserCreate.Should()
-            .BeFalse();
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.DisallowUserDelete.Should()
-            .BeFalse();
+        Assert.False(
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.DisallowUserCreate
+        );
+        Assert.False(
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.DisallowUserDelete
+        );
     }
 
     [Fact]
@@ -33,13 +30,11 @@ public class AllowUserActions
                 "AllowUserActions.applicationMetadata_afterChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.DisallowUserCreate.Should()
-            .BeTrue();
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.DisallowUserDelete.Should()
-            .BeFalse();
+        Assert.True(
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.DisallowUserCreate
+        );
+        Assert.False(
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.DisallowUserDelete
+        );
     }
 }

--- a/test/Altinn.Platform.Storage.Interface.Tests/Altinn.Platform.Storage.Interface.Tests.csproj
+++ b/test/Altinn.Platform.Storage.Interface.Tests/Altinn.Platform.Storage.Interface.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/Altinn.Platform.Storage.Interface.Tests/ShadowFields/ApplicationTestsForShadowFields.cs
+++ b/test/Altinn.Platform.Storage.Interface.Tests/ShadowFields/ApplicationTestsForShadowFields.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Altinn.Platform.Storage.Interface.Models;
-using FluentAssertions;
 using Xunit;
 
 namespace Altinn.Platform.Storage.Interface.Tests;
@@ -15,10 +14,9 @@ public class ApplicationTestsForShadowFields
                 "ShadowFields.applicationMetadata_beforeChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.ShadowFields.Should()
-            .BeNull();
+        Assert.Null(
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.ShadowFields
+        );
     }
 
     [Fact]
@@ -29,13 +27,15 @@ public class ApplicationTestsForShadowFields
                 "ShadowFields.applicationMetadata_afterChange.json"
             );
 
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.ShadowFields.Prefix.Should()
-            .Be("AltinnSF_");
-        applicationBefore
-            .DataTypes.First(d => d.Id == "Veileder")
-            .AppLogic.ShadowFields.SaveToDataType.Should()
-            .Be("model-clean");
+        Assert.Equal(
+            "AltinnSF_",
+            applicationBefore.DataTypes.First(d => d.Id == "Veileder").AppLogic.ShadowFields.Prefix
+        );
+        Assert.Equal(
+            "model-clean",
+            applicationBefore
+                .DataTypes.First(d => d.Id == "Veileder")
+                .AppLogic.ShadowFields.SaveToDataType
+        );
     }
 }

--- a/test/Altinn.Platform.Storage.Interface.Tests/SystemUser/PlatformUserTests.cs
+++ b/test/Altinn.Platform.Storage.Interface.Tests/SystemUser/PlatformUserTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Altinn.Platform.Storage.Interface.Models;
-using FluentAssertions;
 using Xunit;
 
 namespace Altinn.Platform.Storage.Interface.Tests.SystemUser;
@@ -14,9 +13,9 @@ public class PlatformUserTests
             "SystemUser.platformUser_beforeChange.json"
         );
 
-        target.SystemUserId.Should().BeNull();
-        target.SystemUserName.Should().BeNull();
-        target.SystemUserOwnerOrgNo.Should().BeNull();
+        Assert.Null(target.SystemUserId);
+        Assert.Null(target.SystemUserName);
+        Assert.Null(target.SystemUserOwnerOrgNo);
     }
 
     [Fact]
@@ -26,8 +25,8 @@ public class PlatformUserTests
             "SystemUser.platformUser_afterChange.json"
         );
 
-        target.SystemUserId.Should().Be(Guid.Parse("2280457B-0A79-49C5-AC14-09217705C9A1"));
-        target.SystemUserName.Should().Be("Vismalise");
-        target.SystemUserOwnerOrgNo.Should().Be("565433454");
+        Assert.Equal(Guid.Parse("2280457B-0A79-49C5-AC14-09217705C9A1"), target.SystemUserId);
+        Assert.Equal("Vismalise", target.SystemUserName);
+        Assert.Equal("565433454", target.SystemUserOwnerOrgNo);
     }
 }


### PR DESCRIPTION
Usage was very limited and the next major version is not free

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test assertions to use standard xUnit assertions instead of fluent-style assertions across multiple test files.
  * Removed FluentAssertions package dependency.
  * Test behavior and functionality remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->