### PR TITLE
Pass cancellation token CA2016

### DIFF
--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -171,7 +171,11 @@ public class CleanupController(
                         false,
                         cancellationToken
                     );
-                    app = await applicationRepository.FindOne(instance.AppId, instance.Org);
+                    app = await applicationRepository.FindOne(
+                        instance.AppId,
+                        instance.Org,
+                        cancellationToken
+                    );
                 }
 
                 if (
@@ -189,7 +193,7 @@ public class CleanupController(
                     );
                 }
 
-                if (!await dataRepository.Delete(dataElement))
+                if (!await dataRepository.Delete(dataElement, cancellationToken))
                 {
                     _logger.LogError(
                         "CleanupController // CleanupDataelements // Data element not found for dataElement Id: {dataElement.Id}",

--- a/src/Storage/Controllers/ContentOnDemandController.cs
+++ b/src/Storage/Controllers/ContentOnDemandController.cs
@@ -113,7 +113,8 @@ public class ContentOnDemandController : Controller
         );
         Application application = await _applicationRepository.FindOne(
             instance.AppId,
-            instance.Org
+            instance.Org,
+            cancellationToken
         );
         DataElement signatureElement = instance.Data.First(d => d.DataType == "signature-data");
 
@@ -121,7 +122,8 @@ public class ContentOnDemandController : Controller
             await _blobRepository.ReadBlob(
                 $"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}",
                 $"{instance.Org}/{app}/{instanceGuid}/data/{signatureElement.Id}",
-                application.StorageAccountNumber
+                application.StorageAccountNumber,
+                cancellationToken
             ),
             (JsonSerializerOptions)null,
             cancellationToken
@@ -157,7 +159,8 @@ public class ContentOnDemandController : Controller
         );
         Application application = await _applicationRepository.FindOne(
             instance.AppId,
-            instance.Org
+            instance.Org,
+            cancellationToken
         );
         DataElement paymentElement = instance.Data.First(d => d.DataType == "payment-data");
 
@@ -165,7 +168,8 @@ public class ContentOnDemandController : Controller
             await _blobRepository.ReadBlob(
                 $"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}",
                 $"{instance.Org}/{app}/{instanceGuid}/data/{paymentElement.Id}",
-                application.StorageAccountNumber
+                application.StorageAccountNumber,
+                cancellationToken
             ),
             (JsonSerializerOptions)null,
             cancellationToken

--- a/src/Storage/Controllers/DataLockController.cs
+++ b/src/Storage/Controllers/DataLockController.cs
@@ -90,7 +90,8 @@ public class DataLockController : ControllerBase
             DataElement updatedDataElement = await _dataRepository.Update(
                 instanceGuid,
                 dataGuid,
-                propertyList
+                propertyList,
+                cancellationToken
             );
             return Created(updatedDataElement.Id, updatedDataElement);
         }
@@ -150,7 +151,8 @@ public class DataLockController : ControllerBase
             DataElement updatedDataElement = await _dataRepository.Update(
                 instanceGuid,
                 dataGuid,
-                propertyList
+                propertyList,
+                cancellationToken
             );
             return Ok(updatedDataElement);
         }

--- a/src/Storage/Controllers/MessageboxInstancesController.cs
+++ b/src/Storage/Controllers/MessageboxInstancesController.cs
@@ -197,7 +197,8 @@ public class MessageBoxInstancesController : ControllerBase
         {
             var application = await _applicationRepository.FindOne(
                 instance.AppId,
-                instance.AppId.Split("/")[0]
+                instance.AppId.Split("/")[0],
+                cancellationToken
             );
             includeInstantiate = application?.CopyInstanceSettings?.Enabled == true;
         }

--- a/src/Storage/Controllers/MigrationController.cs
+++ b/src/Storage/Controllers/MigrationController.cs
@@ -227,7 +227,11 @@ public class MigrationController : ControllerBase
             return BadRequest("Instance not found");
         }
 
-        Application app = await _applicationRepository.FindOne(instance.AppId, instance.Org);
+        Application app = await _applicationRepository.FindOne(
+            instance.AppId,
+            instance.Org,
+            cancellationToken
+        );
         bool isA2 = app.Id.Contains("/a2-");
         if (!isA2 && !app.Id.Contains("/a1-"))
         {


### PR DESCRIPTION
When enabeling NETAnalyzers we get warnings when a method has a cancellation token but does not pass it forward to other methods that has cancellationTokenParameter

It is not always correct to pass a cancellationToken (eg, after saving part 1 of something that should have been protected by a transaction), but here I (hopefully) only fix the obvious cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data operation handling across storage controllers with improved cancellation support for better system responsiveness during long-running operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->