### PR TITLE
Turn on filterMigrated to speed up messagebox search

### DIFF
--- a/test/k6/src/tests/messageboxinstances.js
+++ b/test/k6/src/tests/messageboxinstances.js
@@ -91,6 +91,7 @@ function TC02_SearchActiveInstances(data) {
     appId: data.org + "/" + data.app,
     instanceOwnerPartyIdList: [data.partyId],
     includeActive: "true",
+    filterMigrated: "true",
   };
   var res = msgboxApi.searchInstances(data.userToken, queryModel);
 


### PR DESCRIPTION
## Description
Use case tests are currently failing because of what seems like a timeout during message box search. Turning on filtering of migrated elements will hopefully alleviate the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced search filtering validation tests by adding stricter criteria to verify correct filtering behavior for active instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->