### PR TITLE
Set LF line endings for C# files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,9 @@
 # & do unspecified diff behavior (if file content is recognized as text & filesize < core.bigFileThreshold, do text diff on file changes)
 * text=auto
 
+# .editorconfig makes csharpier ensure lf on all platforms
+*.cs text eol=lf
+
 # Override with explicit specific settings for known and/or likely text files in our repo that should be normalized
 # where diff{=optional_pattern} means "do text diff {with specific text pattern} and -diff means "don't do text diffs".
 # Unspecified diff behavior is decribed above


### PR DESCRIPTION
Added .gitattributes setting to enforce LF line endings for C# files on windows also.

## Related Issue(s)
- #868 
- .editorconfig was configured to force LF line endings in #426 @martinothamar 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized line ending configuration for C# source files in repository settings.
  * Applied minor formatting updates to repository configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->