### PR TITLE
Add subformPdf to GetActionsThatAllowProcessNextForTaskType.

### DIFF
--- a/src/Storage/Controllers/ProcessController.cs
+++ b/src/Storage/Controllers/ProcessController.cs
@@ -373,7 +373,10 @@ public class ProcessController : ControllerBase
         return taskType switch
         {
             null => [],
-            "data" or "feedback" or "pdf" or "eFormidling" or "fiksArkiv" => ["write"],
+            "data" or "feedback" or "pdf" or "eFormidling" or "fiksArkiv" or "subformPdf" =>
+            [
+                "write",
+            ],
             "payment" => ["pay", "write"],
             "confirmation" => ["confirm"],
             "signing" => ["sign", "write"],

--- a/test/UnitTest/TestingControllers/ProcessControllerTest.cs
+++ b/test/UnitTest/TestingControllers/ProcessControllerTest.cs
@@ -625,6 +625,7 @@ public class ProcessControllerTest : IClassFixture<TestApplicationFactory<Proces
     [InlineData("pdf", new[] { "write" })]
     [InlineData("eFormidling", new[] { "write" })]
     [InlineData("fiksArkiv", new[] { "write" })]
+    [InlineData("subformPdf", new[] { "write" })]
     [InlineData("payment", new[] { "pay", "write" })]
     [InlineData("confirmation", new[] { "confirm" })]
     [InlineData("signing", new[] { "sign", "write" })]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended write operation support for PDF subform tasks in process workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->