### PR TITLE
fix: dispatch delete event

### DIFF
--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -646,7 +646,7 @@ public class InstancesController : ControllerBase
                 updateProperties,
                 cancellationToken
             );
-            
+
             await _instanceEventService.DispatchEvent(InstanceEventType.Deleted, deletedInstance);
 
             return Ok(deletedInstance);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When an instance is deleted via the app api, we send a delete event to the azure service bus to be picked up by the dialogporten adapter. 

We have observed that this leads to the dialog not being present anywhere in AF, meaning that the user is not able to undelete the dialog from the bin.

tldr: simply send delete event. dialogporten can see if it is hard or soft based on the instance

## Related Issue(s)
- #897

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance deletion handling so deletion now triggers the appropriate system notification, ensuring downstream processes and integrations receive timely updates when an instance is removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->