### PR TITLE
feat: update interface to include user email for self identified users

### DIFF
--- a/src/Storage.Interface/Models/InstanceOwner.cs
+++ b/src/Storage.Interface/Models/InstanceOwner.cs
@@ -27,7 +27,8 @@ public class InstanceOwner
     public string OrganisationNumber { get; set; }
 
     /// <summary>
-    /// Gets or sets the username of the party. Null if the party is not self identified.
+    /// Gets or sets the username of the party. Only set for legacy username-based authentication.
+    /// Null for email-based self-identified users.
     /// Altinn 3 will use ID-Porten self identified users, which are email based.
     /// This property will be removed when Altinn 3 no longer supports username based authentication.
     /// </summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users which are self identified using [id portens email login](https://docs.digdir.no/docs/idporten/oidc/oidc_func_emaillogin.html) do not have a user name, but rather an email address.

To register a self identified user in this manner, the user states their email address and are asked to provide a code which is sent to the email. Thus, the only thing we know about this user is that they own the provided email address.

In altinn 2, users would self identify with a username and password combination, which is the reason for the `InstanceOwner.UserName` property. This property should be removed in due time, when we are certain that this login mechanism is no longer in use.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email field now available to identify self-reported instance owners in profiles and listings. Existing username-based identification remains supported for backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->