### PR TITLE
chore: add sync settings for AditionalInfo and ExtendedStatus

### DIFF
--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -74,6 +74,20 @@ namespace Altinn.Platform.Storage.Interface.Models
         public bool DisableSyncContentSummary { get; set; }
 
         /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the additional information.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncContentAdditionalInformation")]
+        [DefaultValue(false)]
+        public bool DisableSyncContentAdditionalInformation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing (overwrite) the extended status.
+        /// </summary>
+        [JsonProperty(PropertyName = "disableSyncContentExtendedStatus")]
+        [DefaultValue(false)]
+        public bool DisableSyncContentExtendedStatus { get; set; }
+
+        /// <summary>
         /// Gets or sets the flag controlling whether the sync adapter should disable synchronizing attachments at the dialog level.
         /// Will only add/remove attachments with recognized id's, which are derived from the URL.
         /// </summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- Altinn/altinn-dialogporten-adapter/issues/179

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new configuration options to sync adapter settings, enabling users to independently control the synchronization of additional information and extended status. Both options are enabled by default to maintain backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->