### PR TITLE
Add `EnableUserSuppliedDialogId` to SyncAdapterSettings

### DIFF
--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -24,7 +24,7 @@ namespace Altinn.Platform.Storage.Interface.Models
         [JsonProperty(PropertyName = "enableUserSuppliedDialogId")]
         [DefaultValue(false)]
         public bool EnableUserSuppliedDialogId { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the flag controlling whether the sync adapter should disable dialog creation.
         /// </summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/altinn-dialogporten-adapter/issues/180

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to choose whether dialog IDs are auto-generated or taken from user-supplied data (defaults to auto-generate). This expands control over dialog ID handling while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->