### PR TITLE
feat: Add `EnagledSuppliedDialogId` to SyncAdapterSettings

### DIFF
--- a/src/Storage.Interface/Models/SyncAdapterSettings.cs
+++ b/src/Storage.Interface/Models/SyncAdapterSettings.cs
@@ -18,6 +18,14 @@ namespace Altinn.Platform.Storage.Interface.Models
         public bool DisableSync { get; set; }
 
         /// <summary>
+        /// Gets or sets the flag controlling whether the sync adapter should create a dialogId or use user-supplied dialogId.
+        /// If true, the sync adapter will use the dialogId found in DataValues with key: dialog.id.
+        /// </summary>
+        [JsonProperty(PropertyName = "enableUserSuppliedDialogId")]
+        [DefaultValue(false)]
+        public bool EnableUserSuppliedDialogId { get; set; }
+
+        /// <summary>
         /// Gets or sets the flag controlling whether the sync adapter should disable dialog creation.
         /// </summary>
         [JsonProperty(PropertyName = "disableCreate")]


### PR DESCRIPTION
## Description
PR created to run tests on behalf of https://github.com/Altinn/altinn-storage/pull/939

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration setting to enable user-supplied dialog identifiers. When activated, the sync adapter will use dialog IDs from external data sources instead of auto-generating them. Disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->