### PR TITLE
fix: double fetch of instance on get endpoints

### DIFF
--- a/src/Storage.Interface/Directory.Build.props
+++ b/src/Storage.Interface/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Storage.Interface/Directory.Build.props
+++ b/src/Storage.Interface/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -248,6 +248,19 @@ public class AuthorizationService(
         if (!_memoryCache.TryGetValue(cacheKey, out XacmlJsonResponse response))
         {
             response = await _pdp.GetDecisionForRequest(request);
+
+            if (response?.Response is not null)
+            {
+                _memoryCache.Set(
+                    cacheKey,
+                    response,
+                    new MemoryCacheEntryOptions()
+                        .SetPriority(CacheItemPriority.High)
+                        .SetAbsoluteExpiration(
+                            new TimeSpan(0, _pepSettings.PdpDecisionCachingTimeout, 0)
+                        )
+                );
+            }
         }
 
         if (response?.Response == null)
@@ -258,14 +271,6 @@ public class AuthorizationService(
             );
             return false;
         }
-
-        _memoryCache.Set(
-            cacheKey,
-            response,
-            new MemoryCacheEntryOptions()
-                .SetPriority(CacheItemPriority.High)
-                .SetAbsoluteExpiration(new TimeSpan(0, _pepSettings.PdpDecisionCachingTimeout, 0))
-        );
 
         return DecisionHelper.ValidatePdpDecision(response.Response, user);
     }

--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -2,15 +2,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Configuration;
 using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -26,17 +29,23 @@ namespace Altinn.Platform.Storage.Authorization;
 /// <param name="claimsPrincipalProvider">A service providing access to the current <see cref="ClaimsPrincipal"/>.</param>
 /// <param name="logger">The logger</param>
 /// <param name="settings">General configuration settings</param>
+/// <param name="memoryCache">The memory cache</param>
+/// <param name="pepSettings">The settings for pep</param>
 public class AuthorizationService(
     IPDP pdp,
     IClaimsPrincipalProvider claimsPrincipalProvider,
     ILogger<AuthorizationService> logger,
-    IOptions<GeneralSettings> settings
+    IOptions<GeneralSettings> settings,
+    IMemoryCache memoryCache,
+    IOptions<PepSettings> pepSettings
 ) : IAuthorization
 {
     private readonly IPDP _pdp = pdp;
     private readonly IClaimsPrincipalProvider _claimsPrincipalProvider = claimsPrincipalProvider;
     private readonly ILogger<AuthorizationService> _logger = logger;
     private readonly GeneralSettings _settings = settings.Value;
+    private readonly IMemoryCache _memoryCache = memoryCache;
+    private readonly PepSettings _pepSettings = pepSettings.Value;
 
     private const string XacmlResourceTaskId = "urn:altinn:task";
     private const string XacmlResourceEndId = "urn:altinn:end-event";
@@ -213,6 +222,54 @@ public class AuthorizationService(
 
         bool authorized = DecisionHelper.ValidatePdpDecision(response.Response, user);
         return authorized;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> AuthorizeEnrichedInstanceAction(Instance instance, string action)
+    {
+        string org = instance.Org;
+        string app = instance.AppId.Split('/')[1];
+        int instanceOwnerPartyId = int.Parse(instance.InstanceOwner.PartyId);
+
+        ClaimsPrincipal user = _claimsPrincipalProvider.GetUser();
+        Guid instanceGuid = Guid.Parse(instance.Id.Split('/')[1]);
+        XacmlJsonRequestRoot request = DecisionHelper.CreateDecisionRequest(
+            org,
+            app,
+            user,
+            action,
+            instanceOwnerPartyId,
+            instanceGuid
+        );
+
+        EnrichXacmlJsonRequest(request, instance);
+
+        string cacheKey = GetCacheKeyForDecisionRequest(request);
+        if (!_memoryCache.TryGetValue(cacheKey, out XacmlJsonResponse response))
+        {
+            response = await _pdp.GetDecisionForRequest(request);
+
+            _memoryCache.Set(
+                cacheKey,
+                response,
+                new MemoryCacheEntryOptions()
+                    .SetPriority(CacheItemPriority.High)
+                    .SetAbsoluteExpiration(
+                        new TimeSpan(0, _pepSettings.PdpDecisionCachingTimeout, 0)
+                    )
+            );
+        }
+
+        if (response?.Response == null)
+        {
+            _logger.LogInformation(
+                "// Authorization Helper // AuthorizeEnrichedInstanceAction failed for request: {request}.",
+                JsonSerializer.Serialize(request)
+            );
+            return false;
+        }
+
+        return DecisionHelper.ValidatePdpDecision(response.Response, user);
     }
 
     /// <inheritdoc />
@@ -660,5 +717,42 @@ public class AuthorizationService(
         }
 
         return references;
+    }
+
+    /// <summary>
+    /// This method creates a uniqe cache key based on all relevant attributes in a decision request
+    /// </summary>
+    /// <param name="request">The decision request</param>
+    /// <returns>The cache key</returns>
+    private static string GetCacheKeyForDecisionRequest(XacmlJsonRequestRoot request)
+    {
+        StringBuilder resourceKey = new();
+        foreach (XacmlJsonCategory category in request.Request.Resource)
+        {
+            foreach (XacmlJsonAttribute atr in category.Attribute)
+            {
+                resourceKey.Append(atr.AttributeId + ":" + atr.Value + ";");
+            }
+        }
+
+        StringBuilder subjectKey = new();
+        foreach (XacmlJsonCategory category in request.Request.AccessSubject)
+        {
+            foreach (XacmlJsonAttribute atr in category.Attribute)
+            {
+                subjectKey.Append(atr.AttributeId + ":" + atr.Value + ";");
+            }
+        }
+
+        StringBuilder actionKey = new();
+        foreach (XacmlJsonCategory category in request.Request.Action)
+        {
+            foreach (XacmlJsonAttribute atr in category.Attribute)
+            {
+                actionKey.Append(atr.AttributeId + ":" + atr.Value + ";");
+            }
+        }
+
+        return subjectKey.ToString() + actionKey.ToString() + resourceKey.ToString();
     }
 }

--- a/src/Storage/Authorization/AuthorizationService.cs
+++ b/src/Storage/Authorization/AuthorizationService.cs
@@ -248,16 +248,6 @@ public class AuthorizationService(
         if (!_memoryCache.TryGetValue(cacheKey, out XacmlJsonResponse response))
         {
             response = await _pdp.GetDecisionForRequest(request);
-
-            _memoryCache.Set(
-                cacheKey,
-                response,
-                new MemoryCacheEntryOptions()
-                    .SetPriority(CacheItemPriority.High)
-                    .SetAbsoluteExpiration(
-                        new TimeSpan(0, _pepSettings.PdpDecisionCachingTimeout, 0)
-                    )
-            );
         }
 
         if (response?.Response == null)
@@ -268,6 +258,14 @@ public class AuthorizationService(
             );
             return false;
         }
+
+        _memoryCache.Set(
+            cacheKey,
+            response,
+            new MemoryCacheEntryOptions()
+                .SetPriority(CacheItemPriority.High)
+                .SetAbsoluteExpiration(new TimeSpan(0, _pepSettings.PdpDecisionCachingTimeout, 0))
+        );
 
         return DecisionHelper.ValidatePdpDecision(response.Response, user);
     }

--- a/src/Storage/Authorization/IAuthorization.cs
+++ b/src/Storage/Authorization/IAuthorization.cs
@@ -27,6 +27,14 @@ public interface IAuthorization
     public Task<bool> AuthorizeInstanceAction(Instance instance, string action, string task = null);
 
     /// <summary>
+    /// Authorizes a read action on an instance, enriching the XACML request with full instance context
+    /// including current task and end event. Prefer this over AuthorizeInstanceAction when the full
+    /// instance is available and process state context is needed.
+    /// </summary>
+    /// <returns>true if the user is authorized.</returns>
+    public Task<bool> AuthorizeEnrichedInstanceAction(Instance instance, string action);
+
+    /// <summary>
     /// Authorizes that the user has one or more of the actions on an instance.
     /// </summary>
     /// <returns>true if the user is authorized.</returns>

--- a/src/Storage/Authorization/StorageAccessHandler.cs
+++ b/src/Storage/Authorization/StorageAccessHandler.cs
@@ -168,7 +168,7 @@ public class StorageAccessHandler : AuthorizationHandler<AppAccessRequirement>
     }
 
     /// <summary>
-    /// This method creates a uniqe cache key based on all relevant attributes in a decision request
+    /// This method creates a unique cache key based on all relevant attributes in a decision request
     /// </summary>
     /// <param name="request">The decision requonst</param>
     /// <returns>The cache key</returns>

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -197,7 +197,7 @@ public class DataController : ControllerBase
     /// <param name="dataGuid">The id of the data element to retrieve.</param>
     /// <param name="cancellationToken">CancellationToken</param>
     /// <returns>The data file as a stream.</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
+    [Authorize]
     [HttpGet("data/{dataGuid:guid}")]
     [RequestSizeLimit(RequestSizeLimit)]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -225,6 +225,11 @@ public class DataController : ControllerBase
         if (instance == null)
         {
             return instanceError;
+        }
+
+        if (await _authorizationService.AuthorizeEnrichedInstanceAction(instance, "read") is false)
+        {
+            return Forbid();
         }
 
         (DataElement dataElement, ActionResult dataElementError) = await GetDataElementAsync(
@@ -354,7 +359,7 @@ public class DataController : ControllerBase
     /// <param name="instanceGuid">The id of the instance that the data element is associated with.</param>
     /// <param name="cancellationToken">CancellationToken</param>
     /// <returns>The list of data elements</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
+    [Authorize]
     [HttpGet("dataelements")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -379,6 +384,11 @@ public class DataController : ControllerBase
         if (instance == null)
         {
             return instanceError;
+        }
+
+        if (await _authorizationService.AuthorizeEnrichedInstanceAction(instance, "read") is false)
+        {
+            return Forbid();
         }
 
         bool appOwnerRequestingElement = User.GetOrg() == instance.Org;

--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -363,7 +363,7 @@ public class InstancesController : ControllerBase
     /// <param name="instanceGuid">The id of the instance to retrieve.</param>
     /// <param name="cancellationToken">CancellationToken</param>
     /// <returns>The information about the specific instance.</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
+    [Authorize]
     [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -376,25 +376,37 @@ public class InstancesController : ControllerBase
     {
         try
         {
-            (Instance result, _) = await _instanceRepository.GetOne(
+            (Instance instance, _) = await _instanceRepository.GetOne(
                 instanceGuid,
                 true,
                 cancellationToken
             );
 
             if (
-                User.GetOrg() != result.Org
-                && !_authorizationService.UserHasRequiredScope([
+                _authorizationService.UserHasRequiredScope([
                     _generalSettings.InstanceSyncAdapterScope,
                 ])
             )
             {
-                FilterOutDeletedDataElements(result);
+                instance.SetPlatformSelfLinks(_storageBaseAndHost);
+                return Ok(instance);
             }
 
-            result.SetPlatformSelfLinks(_storageBaseAndHost);
+            if (
+                await _authorizationService.AuthorizeEnrichedInstanceAction(instance, "read")
+                is false
+            )
+            {
+                return Forbid();
+            }
 
-            return Ok(result);
+            if (User.GetOrg() != instance.Org)
+            {
+                FilterOutDeletedDataElements(instance);
+            }
+
+            instance.SetPlatformSelfLinks(_storageBaseAndHost);
+            return Ok(instance);
         }
         catch (Exception e)
         {
@@ -409,7 +421,7 @@ public class InstancesController : ControllerBase
     /// <param name="instanceGuid">The id of the instance to retrieve.</param>
     /// <param name="cancellationToken">CancellationToken</param>
     /// <returns>The information about the specific instance.</returns>
-    [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
+    [Authorize]
     [HttpGet("{instanceGuid:guid}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -421,25 +433,37 @@ public class InstancesController : ControllerBase
     {
         try
         {
-            (Instance result, _) = await _instanceRepository.GetOne(
+            (Instance instance, _) = await _instanceRepository.GetOne(
                 instanceGuid,
                 true,
                 cancellationToken
             );
 
             if (
-                User.GetOrg() != result.Org
-                && !_authorizationService.UserHasRequiredScope([
+                _authorizationService.UserHasRequiredScope([
                     _generalSettings.InstanceSyncAdapterScope,
                 ])
             )
             {
-                FilterOutDeletedDataElements(result);
+                instance.SetPlatformSelfLinks(_storageBaseAndHost);
+                return Ok(instance);
             }
 
-            result.SetPlatformSelfLinks(_storageBaseAndHost);
+            if (
+                await _authorizationService.AuthorizeEnrichedInstanceAction(instance, "read")
+                is false
+            )
+            {
+                return Forbid();
+            }
 
-            return Ok(result);
+            if (User.GetOrg() != instance.Org)
+            {
+                FilterOutDeletedDataElements(instance);
+            }
+
+            instance.SetPlatformSelfLinks(_storageBaseAndHost);
+            return Ok(instance);
         }
         catch (Exception e)
         {

--- a/src/Storage/Telemetry/AspNetCoreMetricsEnricher.cs
+++ b/src/Storage/Telemetry/AspNetCoreMetricsEnricher.cs
@@ -173,6 +173,8 @@ internal sealed class CustomActionDescriptorProvider : IActionDescriptorProvider
         StringComparer.Ordinal,
         "Altinn.Platform.Storage.Controllers.DataLockController.Unlock (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.InstancesController.GetInstances (Altinn.Platform.Storage)",
+        "Altinn.Platform.Storage.Controllers.InstancesController.Get (Altinn.Platform.Storage)",
+        "Altinn.Platform.Storage.Controllers.InstancesController.GetByGuid (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.InstancesController.Post (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.InstancesController.UpdateSubstatus (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.ProcessController.PutInstanceAndEvents (Altinn.Platform.Storage)",

--- a/src/Storage/Telemetry/AspNetCoreMetricsEnricher.cs
+++ b/src/Storage/Telemetry/AspNetCoreMetricsEnricher.cs
@@ -177,6 +177,8 @@ internal sealed class CustomActionDescriptorProvider : IActionDescriptorProvider
         "Altinn.Platform.Storage.Controllers.InstancesController.GetByGuid (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.InstancesController.Post (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.InstancesController.UpdateSubstatus (Altinn.Platform.Storage)",
+        "Altinn.Platform.Storage.Controllers.DataController.Get (Altinn.Platform.Storage)",
+        "Altinn.Platform.Storage.Controllers.DataController.GetMany (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.ProcessController.PutInstanceAndEvents (Altinn.Platform.Storage)",
         "Altinn.Platform.Storage.Controllers.ProcessController.PutProcess (Altinn.Platform.Storage)"
     );

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -424,6 +424,10 @@ public class DataControllerUnitTests
             )
         );
 
+        authorizationServiceMock
+            .Setup(a => a.AuthorizeEnrichedInstanceAction(It.IsAny<Instance>(), It.IsAny<string>()))
+            .ReturnsAsync(true);
+
         Mock<HttpContext> httpContextMock = new();
         httpContextMock.Setup(c => c.User).Returns(PrincipalUtil.GetPrincipal(200001, 1337));
 

--- a/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
+++ b/test/UnitTest/TestingServices/AuthorizationServiceTest.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+using Altinn.Common.PEP.Configuration;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Configuration;
@@ -12,6 +13,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.UnitTest.Mocks;
 using AltinnCore.Authentication.Constants;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -43,7 +45,9 @@ public class AuthorizationServiceTest
             _pdpMockSI,
             _claimsPrincipalProviderMock.Object,
             Mock.Of<ILogger<AuthorizationService>>(),
-            options
+            options,
+            Mock.Of<IMemoryCache>(),
+            Options.Create(new PepSettings())
         );
     }
 
@@ -66,7 +70,9 @@ public class AuthorizationServiceTest
             _pdpSimpleMock.Object,
             _claimsPrincipalProviderMock.Object,
             Mock.Of<ILogger<AuthorizationService>>(),
-            options
+            options,
+            Mock.Of<IMemoryCache>(),
+            Options.Create(new PepSettings())
         );
         await sut.GetDecisionForRequest(new XacmlJsonRequestRoot());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not want to remove StorageAccessHandler in its entirety in this PR.

Move the auth for the instance get endpoints to inline service calls. Added cache to the new service method, reusing the code from the handler. Added the endpoints manually to the telemetry as it no longer picks them up automatically

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced authorization system now enriches authorization decisions with full instance context (organization, application, user details, and owner information) for more granular access control across instance and data endpoints.
  * Implemented authorization decision caching to improve performance.

* **Documentation**
  * Fixed documentation typo in authorization handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->