### PR TITLE
feat: add query parameter `includeDataElements`

### DIFF
--- a/src/Storage/Controllers/InstancesController.cs
+++ b/src/Storage/Controllers/InstancesController.cs
@@ -293,7 +293,6 @@ public class InstancesController : ControllerBase
         {
             InstanceQueryResponse result = await _instanceRepository.GetInstancesFromQuery(
                 queryParameters,
-                true,
                 cancellationToken
             );
 

--- a/src/Storage/Models/InstanceQueryParameters.cs
+++ b/src/Storage/Models/InstanceQueryParameters.cs
@@ -193,7 +193,7 @@ public class InstanceQueryParameters
     /// </summary>
     [DefaultValue(true)]
     [FromQuery(Name = _includeDataElements)]
-    public bool? IncludeDataElements { get; set; }
+    public bool IncludeDataElements { get; set; } = true;
 
     /// <summary>
     /// Gets or sets an array of application identifiers.

--- a/src/Storage/Models/InstanceQueryParameters.cs
+++ b/src/Storage/Models/InstanceQueryParameters.cs
@@ -46,6 +46,7 @@ public class InstanceQueryParameters
     private const string _sortAscendingParameterName = "_sort_ascending";
     private const string _continueIndexParameterName = "_continue_idx";
     private const string _lastChangedIndexParameterName = "_lastChanged_idx";
+    private const string _includeDataElements = "includeDataElements";
 
     /// <summary>
     /// The organization identifier.
@@ -186,6 +187,13 @@ public class InstanceQueryParameters
     /// </summary>
     [FromQuery(Name = _sortAscendingDatabindName)]
     public string SortBy { get; set; }
+
+    /// <summary>
+    /// Should query include data elements
+    /// </summary>
+    [DefaultValue(true)]
+    [FromQuery(Name = _includeDataElements)]
+    public bool IncludeDataElements { get; set; }
 
     /// <summary>
     /// Gets or sets an array of application identifiers.

--- a/src/Storage/Models/InstanceQueryParameters.cs
+++ b/src/Storage/Models/InstanceQueryParameters.cs
@@ -193,7 +193,7 @@ public class InstanceQueryParameters
     /// </summary>
     [DefaultValue(true)]
     [FromQuery(Name = _includeDataElements)]
-    public bool IncludeDataElements { get; set; }
+    public bool? IncludeDataElements { get; set; }
 
     /// <summary>
     /// Gets or sets an array of application identifiers.

--- a/src/Storage/Repository/IInstanceRepository.cs
+++ b/src/Storage/Repository/IInstanceRepository.cs
@@ -26,6 +26,17 @@ public interface IInstanceRepository
     );
 
     /// <summary>
+    /// Gets all instances that satisfy given query parameters
+    /// </summary>
+    /// <param name="queryParams">the query params</param>
+    /// <param name="cancellationToken">CancellationToken</param>
+    /// <returns>The query response including the list of instances</returns>
+    Task<InstanceQueryResponse> GetInstancesFromQuery(
+        InstanceQueryParameters queryParams,
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
     /// Get an instance for a given instance id
     /// </summary>
     /// <param name="instanceGuid">the instance guid</param>

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -159,6 +159,28 @@ public class PgInstanceRepository : IInstanceRepository
     }
 
     /// <inheritdoc/>
+    public async Task<InstanceQueryResponse> GetInstancesFromQuery(
+        InstanceQueryParameters queryParams,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            return await GetInstancesInternal(queryParams, queryParams.IncludeDataElements, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error running GetInstancesFromQuery");
+            return new()
+            {
+                Count = 0,
+                Instances = [],
+                Exception = e.Message,
+            };
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<List<Instance>> GetHardDeletedInstances(CancellationToken cancellationToken)
     {
         List<Instance> instances = [];

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -166,7 +166,11 @@ public class PgInstanceRepository : IInstanceRepository
     {
         try
         {
-            return await GetInstancesInternal(queryParams, queryParams.IncludeDataElements, cancellationToken);
+            return await GetInstancesInternal(
+                queryParams,
+                queryParams.IncludeDataElements,
+                cancellationToken
+            );
         }
         catch (Exception e)
         {

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -168,7 +168,7 @@ public class PgInstanceRepository : IInstanceRepository
         {
             return await GetInstancesInternal(
                 queryParams,
-                queryParams.IncludeDataElements ?? true,
+                queryParams.IncludeDataElements,
                 cancellationToken
             );
         }

--- a/src/Storage/Repository/PgInstanceRepository.cs
+++ b/src/Storage/Repository/PgInstanceRepository.cs
@@ -168,7 +168,7 @@ public class PgInstanceRepository : IInstanceRepository
         {
             return await GetInstancesInternal(
                 queryParams,
-                queryParams.IncludeDataElements,
+                queryParams.IncludeDataElements ?? true,
                 cancellationToken
             );
         }

--- a/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -136,6 +136,18 @@ public class InstanceRepositoryMock : IInstanceRepository
         return Task.FromResult(response);
     }
 
+    public Task<InstanceQueryResponse> GetInstancesFromQuery(
+        InstanceQueryParameters queryParams,
+        CancellationToken cancellationToken
+    )
+    {
+        return GetInstancesFromQuery(
+            queryParams,
+            queryParams.IncludeDataElements,
+            cancellationToken
+        );
+    }
+
     public Task<(Instance Instance, long InternalId)> GetOne(
         Guid instanceGuid,
         bool includeElements,

--- a/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -143,7 +143,7 @@ public class InstanceRepositoryMock : IInstanceRepository
     {
         return GetInstancesFromQuery(
             queryParams,
-            queryParams.IncludeDataElements,
+            queryParams.IncludeDataElements ?? true,
             cancellationToken
         );
     }

--- a/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
+++ b/test/UnitTest/Mocks/Repository/InstanceRepositoryMock.cs
@@ -143,7 +143,7 @@ public class InstanceRepositoryMock : IInstanceRepository
     {
         return GetInstancesFromQuery(
             queryParams,
-            queryParams.IncludeDataElements ?? true,
+            queryParams.IncludeDataElements,
             cancellationToken
         );
     }

--- a/test/UnitTest/TestingControllers/InstancesControllerTests.cs
+++ b/test/UnitTest/TestingControllers/InstancesControllerTests.cs
@@ -1254,7 +1254,6 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
         irm.Setup(irm =>
                 irm.GetInstancesFromQuery(
                     It.Is<InstanceQueryParameters>(e => e.IsHardDeleted == false),
-                    It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -1284,7 +1283,6 @@ public class InstancesControllerTests(TestApplicationFactory<InstancesController
         irm.Setup(irm =>
                 irm.GetInstancesFromQuery(
                     It.Is<InstanceQueryParameters>(e => e.IsHardDeleted == false),
-                    It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()
                 )
             )

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -1194,7 +1194,7 @@ public class InstanceTests : IClassFixture<InstanceFixture>
     /// Test GetInstancesFromQuery, IncludeDataElements query parameter
     /// </summary>
     [Fact]
-    public async Task Instance_GetInstancesFromQuery_Without_IncludeDataElements_Ok()
+    public async Task Instance_GetInstancesFromQuery_WithIncludeDataElementsAsQueryParam_Ok()
     {
         // Arrange
         await _instanceFixture.InstanceRepo.Create(
@@ -1235,7 +1235,7 @@ public class InstanceTests : IClassFixture<InstanceFixture>
     /// Test GetInstancesFromQuery with bad date
     /// </summary>
     [Fact]
-    public async Task Instance_GetInstancesFromQuery_Without_IncludeDataElements_InvalidDate()
+    public async Task Instance_GetInstancesFromQuery_WithIncludeDataElementsAsQueryParam_InvalidDate()
     {
         // Arrange
         await _instanceFixture.InstanceRepo.Create(

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -1191,6 +1191,86 @@ public class InstanceTests : IClassFixture<InstanceFixture>
     }
 
     /// <summary>
+    /// Test GetInstancesFromQuery, IncludeDataElements query parameter
+    /// </summary>
+    [Fact]
+    public async Task Instance_GetInstancesFromQuery_Without_IncludeDataElements_Ok()
+    {
+        // Arrange
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_1.Clone(),
+            CancellationToken.None
+        );
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_2.Clone(),
+            CancellationToken.None
+        );
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_3.Clone(),
+            CancellationToken.None
+        );
+
+        // InstanceQueryParameters queryParams = new() { Size = 100 };
+        InstanceQueryParameters queryParams = new() { Size = 100, IncludeDataElements = true };
+
+        // Act
+        var instances3 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(
+            queryParams,
+            CancellationToken.None
+        );
+
+        queryParams.InstanceOwnerPartyId = Convert.ToInt32(
+            TestData.Instance_1_3.InstanceOwner.PartyId
+        );
+        var instances1 = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(
+            queryParams,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.Equal(3, instances3.Count);
+        Assert.Equal(1, instances1.Count);
+    }
+
+    /// <summary>
+    /// Test GetInstancesFromQuery with bad date
+    /// </summary>
+    [Fact]
+    public async Task Instance_GetInstancesFromQuery_Without_IncludeDataElements_InvalidDate()
+    {
+        // Arrange
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_1.Clone(),
+            CancellationToken.None
+        );
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_2.Clone(),
+            CancellationToken.None
+        );
+        await _instanceFixture.InstanceRepo.Create(
+            TestData.Instance_1_3.Clone(),
+            CancellationToken.None
+        );
+
+        InstanceQueryParameters queryParams = new()
+        {
+            Size = 100,
+            ProcessEnded = ["true"],
+            InstanceOwnerPartyId = Convert.ToInt32(TestData.Instance_1_3.InstanceOwner.PartyId),
+        };
+
+        // Act
+        var instances = await _instanceFixture.InstanceRepo.GetInstancesFromQuery(
+            queryParams,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.Equal(0, instances.Count);
+        Assert.NotNull(instances.Exception);
+    }
+
+    /// <summary>
     /// Test create instance with Email-based self identification
     /// </summary>
     [Fact]

--- a/test/UnitTest/TestingRepositories/InstanceTests.cs
+++ b/test/UnitTest/TestingRepositories/InstanceTests.cs
@@ -1210,7 +1210,6 @@ public class InstanceTests : IClassFixture<InstanceFixture>
             CancellationToken.None
         );
 
-        // InstanceQueryParameters queryParams = new() { Size = 100 };
         InstanceQueryParameters queryParams = new() { Size = 100, IncludeDataElements = true };
 
         // Act


### PR DESCRIPTION
## Description
Add new query param and extend interface with a method without `includeDataElements` for `PgInstanceRepository.GetInstancesFromQuery`

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an includeDataElements query parameter for instance queries (defaults to true) so callers can control whether data elements are returned.

* **Bug Fixes**
  * Query handling now respects the includeDataElements setting and returns a safe empty result with error details on failures instead of causing unhandled errors.

* **Tests**
  * Added unit tests for includeDataElements behavior and invalid-query error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->