### PR TITLE
feat(DataElement): Allow updating filename property

### DIFF
--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -774,6 +774,7 @@ public class DataController : ControllerBase
             { "/deleteStatus", dataElement.DeleteStatus },
             { "/lastChanged", dataElement.LastChanged },
             { "/lastChangedBy", dataElement.LastChangedBy },
+            { "/filename", HttpUtility.UrlDecode(dataElement.Filename) },
         };
 
         DataElement updatedDataElement = await _dataRepository.Update(

--- a/test/UnitTest/TestingControllers/DataControllerTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerTests.cs
@@ -1155,6 +1155,61 @@ public class DataControllerTests : IClassFixture<TestApplicationFactory<DataCont
         repoMock.VerifyAll();
     }
 
+    [Fact]
+    public async Task Update_VerifyListOfAllowedPropertiesToUpdate()
+    {
+        // Arrange
+        Mock<IDataRepository> dataRepositoryMock = new();
+        dataRepositoryMock
+            .Setup(dr =>
+                dr.Update(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Dictionary<string, object>>(propertyList =>
+                        propertyList.ContainsKey("/locked")
+                        && propertyList.ContainsKey("/refs")
+                        && propertyList.ContainsKey("/references")
+                        && propertyList.ContainsKey("/tags")
+                        && propertyList.ContainsKey("/userDefinedMetadata")
+                        && propertyList.ContainsKey("/metadata")
+                        && propertyList.ContainsKey("/deleteStatus")
+                        && propertyList.ContainsKey("/lastChanged")
+                        && propertyList.ContainsKey("/lastChangedBy")
+                        && propertyList.ContainsKey("/filename")
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new DataElement());
+
+        string instanceGuid = "649388f0-a2c0-4774-bd11-c870223ed819";
+        string dataGuid = "11f7c994-6681-47a1-9626-fcf6c27308a5";
+        string dataPathWithData =
+            $"{_versionPrefix}/instances/1337/{instanceGuid}/dataelements/{dataGuid}";
+        string token = PrincipalUtil.GetToken(1337, 1337, 3);
+        HttpClient client = GetTestClient(dataRepositoryMock, bearerAuthToken: token);
+
+        DataElement dataElementBody = new()
+        {
+            Id = dataGuid,
+            InstanceGuid = instanceGuid,
+            DataType = "default",
+            Filename = "filename.txt",
+        };
+        HttpContent content = new StringContent(
+            JsonSerializer.Serialize(dataElementBody),
+            System.Text.Encoding.UTF8,
+            "application/json"
+        );
+
+        // Act
+        HttpResponseMessage response = await client.PutAsync(dataPathWithData, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        dataRepositoryMock.VerifyAll();
+    }
+
     private HttpClient GetTestClient(
         Mock<IDataRepository> dataRepositoryMock = null,
         Mock<IBlobRepository> blobRepositoryMock = null,


### PR DESCRIPTION
## Description
Include filename in the list of properties that are allowed to be updated on a DataElement. This property is already included in the OverwriteData-method in the DataController, but is missing from the more general Update-method. This allows updating of filenames after initial upload.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data element filenames can now be updated through the metadata update endpoint.

* **Tests**
  * Added test case to verify filename updates are properly handled alongside other updatable metadata properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->