### PR TITLE
chore: studio should only us appid parameter for queries

### DIFF
--- a/src/Storage/Models/StudioInstanceParameters.cs
+++ b/src/Storage/Models/StudioInstanceParameters.cs
@@ -93,7 +93,6 @@ public class StudioInstanceParameters
     {
         return new InstanceQueryParameters()
         {
-            Org = Org,
             AppId = $"{Org}/{App}",
             ArchiveReference = ArchiveReference,
             ProcessCurrentTask = ProcessCurrentTask,


### PR DESCRIPTION
## Description

If I understood correctly, using both of these as predicates leads to worse perf, `Org` is redundant when we already have `AppId`

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated studio instance parameter handling so the incorrect organization value is no longer applied to the created query parameters.
  * Kept the combined app identifier format (`{Org}/{App}`) to maintain existing routing and lookup behavior.
  * Reduces the risk of misrouting or parameter conflicts introduced by the prior organization assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->