### PR TITLE
fix: disable at24 use case tests

### DIFF
--- a/.github/workflows/use-case-ATX.yml
+++ b/.github/workflows/use-case-ATX.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [AT22, AT23, AT24]
+        environment: [AT22, AT23]
     outputs:
       failed-AT22: ${{ steps.set-failure.outputs.AT22 }}
       failed-AT23: ${{ steps.set-failure.outputs.AT23 }}
-      failed-AT24: ${{ steps.set-failure.outputs.AT24 }}
+      #failed-AT24: ${{ steps.set-failure.outputs.AT24 }}
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     permissions:
@@ -86,14 +86,14 @@ jobs:
     permissions: {}
     strategy:
       matrix:
-        environment: [AT22, AT23, AT24]
+        environment: [AT22, AT23]
         include:
           - environment: AT22
             output: failed-AT22
           - environment: AT23
             output: failed-AT23
-          - environment: AT24
-            output: failed-AT24
+          #- environment: AT24
+          #  output: failed-AT24
     runs-on: ubuntu-latest
     steps:
       - name: Send notification


### PR DESCRIPTION
## Description
Disabling AT24 use case tests temporarily while authorisation updates the enviorment.

Test run: https://github.com/Altinn/altinn-storage/actions/runs/26277085495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to remove AT24 environment from test runs and notifications. Testing and reporting will now run only for AT22 and AT23 environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-storage/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->