### PR TITLE
feat: disable A2 endpoints

### DIFF
--- a/src/Storage/Clients/CorrespondenceClient.cs
+++ b/src/Storage/Clients/CorrespondenceClient.cs
@@ -35,22 +35,25 @@ public class CorrespondenceClient : ICorrespondenceClient
     {
         _generalSettings = generalSettings.Value;
         _client = client;
-        var endpoint = _generalSettings.BridgeApiCorrespondenceEndpoint;
-        if (endpoint is null)
+        if (!_generalSettings.DisableA2Endpoints)
         {
-            throw new InvalidOperationException(
-                "GeneralSettings.BridgeApiCorrespondenceEndpoint must be configured."
-            );
-        }
+            var endpoint = _generalSettings.BridgeApiCorrespondenceEndpoint;
+            if (endpoint is null)
+            {
+                throw new InvalidOperationException(
+                    "GeneralSettings.BridgeApiCorrespondenceEndpoint must be configured."
+                );
+            }
 
-        // Ensure trailing slash so relative routes append rather than replace the last segment
-        var endpointStr = endpoint.ToString().Trim();
-        if (!endpointStr.EndsWith('/'))
-        {
-            endpoint = new Uri(endpointStr + "/", UriKind.Absolute);
-        }
+            // Ensure trailing slash so relative routes append rather than replace the last segment
+            var endpointStr = endpoint.ToString().Trim();
+            if (!endpointStr.EndsWith('/'))
+            {
+                endpoint = new Uri(endpointStr + "/", UriKind.Absolute);
+            }
 
-        _client.BaseAddress = endpoint;
+            _client.BaseAddress = endpoint;
+        }
 
         _client.Timeout = new TimeSpan(0, 0, 30);
         _client.DefaultRequestHeaders.Clear();

--- a/src/Storage/Clients/CorrespondenceClient.cs
+++ b/src/Storage/Clients/CorrespondenceClient.cs
@@ -53,13 +53,12 @@ public class CorrespondenceClient : ICorrespondenceClient
             }
 
             _client.BaseAddress = endpoint;
+            _client.Timeout = new TimeSpan(0, 0, 30);
+            _client.DefaultRequestHeaders.Clear();
+            _client.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/json")
+            );
         }
-
-        _client.Timeout = new TimeSpan(0, 0, 30);
-        _client.DefaultRequestHeaders.Clear();
-        _client.DefaultRequestHeaders.Accept.Add(
-            new MediaTypeWithQualityHeaderValue("application/json")
-        );
     }
 
     /// <inheritdoc />

--- a/src/Storage/Clients/CorrespondenceClient.cs
+++ b/src/Storage/Clients/CorrespondenceClient.cs
@@ -67,7 +67,8 @@ public class CorrespondenceClient : ICorrespondenceClient
         string eventType
     )
     {
-        if (_generalSettings.DisableA2Endpoints) return;
+        if (_generalSettings.DisableA2Endpoints)
+            return;
 
         if (!_routes.TryGetValue(eventType, out string route))
         {

--- a/src/Storage/Clients/CorrespondenceClient.cs
+++ b/src/Storage/Clients/CorrespondenceClient.cs
@@ -15,6 +15,7 @@ namespace Altinn.Platform.Storage.Clients;
 /// </summary>
 public class CorrespondenceClient : ICorrespondenceClient
 {
+    private readonly GeneralSettings _generalSettings;
     private readonly HttpClient _client;
     private readonly Dictionary<string, string> _routes = new Dictionary<string, string>(
         StringComparer.OrdinalIgnoreCase
@@ -32,8 +33,9 @@ public class CorrespondenceClient : ICorrespondenceClient
     /// <param name="generalSettings">The general settings configured for Storage.</param>
     public CorrespondenceClient(HttpClient client, IOptions<GeneralSettings> generalSettings)
     {
+        _generalSettings = generalSettings.Value;
         _client = client;
-        var endpoint = generalSettings.Value.BridgeApiCorrespondenceEndpoint;
+        var endpoint = _generalSettings.BridgeApiCorrespondenceEndpoint;
         if (endpoint is null)
         {
             throw new InvalidOperationException(
@@ -65,6 +67,8 @@ public class CorrespondenceClient : ICorrespondenceClient
         string eventType
     )
     {
+        if (_generalSettings.DisableA2Endpoints) return;
+
         if (!_routes.TryGetValue(eventType, out string route))
         {
             throw new ArgumentException($"Invalid event type: {eventType}", nameof(eventType));

--- a/src/Storage/Clients/PartiesWithInstancesClient.cs
+++ b/src/Storage/Clients/PartiesWithInstancesClient.cs
@@ -38,7 +38,8 @@ public class PartiesWithInstancesClient : IPartiesWithInstancesClient
     /// <inheritdoc />
     public async Task SetHasAltinn3Correspondence(int partyId)
     {
-        if (_generalSettings.DisableA2Endpoints) return;
+        if (_generalSettings.DisableA2Endpoints)
+            return;
 
         StringContent content = new StringContent(
             partyId.ToString(),
@@ -51,7 +52,8 @@ public class PartiesWithInstancesClient : IPartiesWithInstancesClient
     /// <inheritdoc />
     public async Task SetHasAltinn3Instances(int instanceOwnerPartyId)
     {
-        if (_generalSettings.DisableA2Endpoints) return;
+        if (_generalSettings.DisableA2Endpoints)
+            return;
 
         StringContent content = new StringContent(
             instanceOwnerPartyId.ToString(),

--- a/src/Storage/Clients/PartiesWithInstancesClient.cs
+++ b/src/Storage/Clients/PartiesWithInstancesClient.cs
@@ -16,6 +16,7 @@ namespace Altinn.Platform.Storage.Clients;
 public class PartiesWithInstancesClient : IPartiesWithInstancesClient
 {
     private readonly HttpClient _client;
+    private readonly GeneralSettings _generalSettings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PartiesWithInstancesClient"/> class with the given HttpClient and GeneralSettings.
@@ -24,8 +25,9 @@ public class PartiesWithInstancesClient : IPartiesWithInstancesClient
     /// <param name="generalSettings">The general settings configured for Storage.</param>
     public PartiesWithInstancesClient(HttpClient client, IOptions<GeneralSettings> generalSettings)
     {
+        _generalSettings = generalSettings.Value;
         _client = client;
-        _client.BaseAddress = generalSettings.Value.BridgeApiAuthorizationEndpoint;
+        _client.BaseAddress = _generalSettings.BridgeApiAuthorizationEndpoint;
         _client.Timeout = new TimeSpan(0, 0, 30);
         _client.DefaultRequestHeaders.Clear();
         _client.DefaultRequestHeaders.Accept.Add(
@@ -36,6 +38,8 @@ public class PartiesWithInstancesClient : IPartiesWithInstancesClient
     /// <inheritdoc />
     public async Task SetHasAltinn3Correspondence(int partyId)
     {
+        if (_generalSettings.DisableA2Endpoints) return;
+
         StringContent content = new StringContent(
             partyId.ToString(),
             Encoding.UTF8,
@@ -47,6 +51,8 @@ public class PartiesWithInstancesClient : IPartiesWithInstancesClient
     /// <inheritdoc />
     public async Task SetHasAltinn3Instances(int instanceOwnerPartyId)
     {
+        if (_generalSettings.DisableA2Endpoints) return;
+
         StringContent content = new StringContent(
             instanceOwnerPartyId.ToString(),
             Encoding.UTF8,

--- a/src/Storage/Configuration/GeneralSettings.cs
+++ b/src/Storage/Configuration/GeneralSettings.cs
@@ -100,4 +100,9 @@ public class GeneralSettings
     /// Gets or sets whether to use sign as an action when authorizing A2 search requests.
     /// </summary>
     public bool AuthorizeA2ListInstancesSign { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to disable A2 endpoints.
+    /// </summary>
+    public bool DisableA2Endpoints { get; set; } = false;
 }

--- a/src/Storage/Configuration/GeneralSettings.cs
+++ b/src/Storage/Configuration/GeneralSettings.cs
@@ -102,7 +102,7 @@ public class GeneralSettings
     public bool AuthorizeA2ListInstancesSign { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets whether to disable A2 endpoints.
+    /// Gets or sets whether to disable Altinn 2 endpoints.
     /// </summary>
     public bool DisableA2Endpoints { get; set; } = false;
 }

--- a/src/Storage/Controllers/SblBridgeController.cs
+++ b/src/Storage/Controllers/SblBridgeController.cs
@@ -5,11 +5,13 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Clients;
+using Altinn.Platform.Storage.Configuration;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.Platform.Storage.Controllers;
 
@@ -34,15 +36,18 @@ public class SblBridgeController : ControllerBase
     /// </summary>
     public SblBridgeController(
         IPartiesWithInstancesClient partiesWithInstancesClient,
-        ICorrespondenceClient correspondenceClient
+        ICorrespondenceClient correspondenceClient,
+        IOptions<GeneralSettings> generalSettings
     )
     {
         _partiesWithInstancesClient = partiesWithInstancesClient;
         _correspondenceClient = correspondenceClient;
+        _generalSettings = generalSettings.Value;
     }
 
     private readonly IPartiesWithInstancesClient _partiesWithInstancesClient;
     private readonly ICorrespondenceClient _correspondenceClient;
+    private readonly GeneralSettings _generalSettings;
 
     /// <summary>
     /// Endpoint to register Altinn 3 Correspondence recipient in SBL Bridge
@@ -53,10 +58,18 @@ public class SblBridgeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Produces("application/json")]
+    [Obsolete("This endpoint is deprecated and will be removed in a future version.")]
     public async Task<ActionResult> RegisterAltinn3CorrespondenceRecipient(
         [FromBody] SblBridgeParty sblBridgeParty
     )
     {
+        if (_generalSettings.DisableA2Endpoints)
+        {
+            return StatusCode(
+                StatusCodes.Status410Gone,
+                "This endpoint is disabled because Altinn 2 is no longer supported."
+            );
+        }
         if (sblBridgeParty.PartyId <= 0)
         {
             return BadRequest("PartyId must be larger than zero");
@@ -77,10 +90,19 @@ public class SblBridgeController : ControllerBase
     [ProducesResponseType(StatusCodes.Status502BadGateway)]
     [ProducesResponseType(StatusCodes.Status504GatewayTimeout)]
     [Produces("application/json")]
+    [Obsolete("This endpoint is deprecated and will be removed in a future version.")]
     public async Task<ActionResult> SyncAltinn3CorrespondenceEvent(
         [FromBody] CorrespondenceEventSync correspondenceEventSync
     )
     {
+        if (_generalSettings.DisableA2Endpoints)
+        {
+            return StatusCode(
+                StatusCodes.Status410Gone,
+                "This endpoint is disabled because Altinn 2 is no longer supported."
+            );
+        }
+
         if (correspondenceEventSync.CorrespondenceId <= 0)
         {
             return BadRequest("CorrespondenceId must be larger than zero");

--- a/src/Storage/Controllers/SblBridgeController.cs
+++ b/src/Storage/Controllers/SblBridgeController.cs
@@ -57,6 +57,7 @@ public class SblBridgeController : ControllerBase
     [Authorize(Policy = AuthzConstants.POLICY_CORRESPONDENCE_SBLBRIDGE)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status410Gone)]
     [Produces("application/json")]
     [Obsolete("This endpoint is deprecated and will be removed in a future version.")]
     public async Task<ActionResult> RegisterAltinn3CorrespondenceRecipient(
@@ -87,6 +88,7 @@ public class SblBridgeController : ControllerBase
     [Authorize(Policy = AuthzConstants.POLICY_CORRESPONDENCE_SBLBRIDGE)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status410Gone)]
     [ProducesResponseType(StatusCodes.Status502BadGateway)]
     [ProducesResponseType(StatusCodes.Status504GatewayTimeout)]
     [Produces("application/json")]

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -27,8 +27,7 @@
     "AppMetadataCacheLifeTimeInSeconds": 300,
     "InstanceReadScope": [ "altinn:serviceowner/instances.read" ],
     "InstanceSyncAdapterScope": "altinn:storage/instances.syncadapter",
-    "MigrationIpWhiteList": "",
-    "DisableA2Endpoints": true
+    "MigrationIpWhiteList": ""
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/",

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -27,7 +27,8 @@
     "AppMetadataCacheLifeTimeInSeconds": 300,
     "InstanceReadScope": [ "altinn:serviceowner/instances.read" ],
     "InstanceSyncAdapterScope": "altinn:storage/instances.syncadapter",
-    "MigrationIpWhiteList": ""
+    "MigrationIpWhiteList": "",
+    "DisableA2Endpoints": true
   },
   "PlatformSettings": {
     "ApiAuthorizationEndpoint": "http://localhost:5050/authorization/api/v1/",


### PR DESCRIPTION
## Description
Disable Altinn 2 endpoints in storage by configuration.

Team `Melding og Formidling` have been informed of the change, they have their own feature flags to disable these calls on their end.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DisableA2Endpoints` configuration setting to control whether Altinn 2 endpoints are available.
  * Altinn 2 compatibility endpoints marked as deprecated and can now be disabled.
  * When disabled, operations targeting Altinn 2 are skipped, reducing unnecessary backend requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-storage/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->