### PR TITLE
refactor: LockDataElement for completed instances

### DIFF
--- a/src/Storage/Authorization/ProcessAuthorizer.cs
+++ b/src/Storage/Authorization/ProcessAuthorizer.cs
@@ -35,12 +35,10 @@ public class ProcessAuthorizer : IProcessAuthorizer
     }
 
     /// <inheritdoc/>
-    public Task<bool> AuthorizeInstanceLock(Instance instance) =>
-        AuthorizeOrFallbackToWrite(instance);
+    public Task<bool> AuthorizeInstanceLock(Instance instance) => Authorize(instance);
 
     /// <inheritdoc/>
-    public Task<bool> AuthorizeDataElementLock(Instance instance) =>
-        AuthorizeOrFallbackToWrite(instance);
+    public Task<bool> AuthorizeDataElementLock(Instance instance) => Authorize(instance);
 
     /// <inheritdoc/>
     public Task<bool> AuthorizePresentationTextsUpdate(Instance instance) => Authorize(instance);
@@ -69,16 +67,6 @@ public class ProcessAuthorizer : IProcessAuthorizer
         };
     }
 
-    private async Task<bool> AuthorizeOrFallbackToWrite(Instance instance)
-    {
-        if (instance.Process?.CurrentTask is null)
-        {
-            return await _authorizationService.AuthorizeInstanceAction(instance, "write");
-        }
-
-        return await Authorize(instance);
-    }
-
     private Task<bool> AuthorizeWithSyncAdapterBypass(Instance instance)
     {
         if (_authorizationService.UserHasRequiredScope(_generalSettings.InstanceSyncAdapterScope))
@@ -89,13 +77,26 @@ public class ProcessAuthorizer : IProcessAuthorizer
         return Authorize(instance);
     }
 
-    private async Task<bool> Authorize(Instance instance, ProcessState? nextProcessState = null)
+    private async Task<bool> Authorize(Instance instance)
     {
-        if (instance.Process?.CurrentTask is null)
+        string? taskId = instance.Process.CurrentTask.ElementId;
+        string? altinnTaskType = instance.Process.CurrentTask.AltinnTaskType;
+
+        List<string> actions = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
+
+        foreach (string action in actions)
         {
-            return false;
+            if (await _authorizationService.AuthorizeInstanceAction(instance, action, taskId))
+            {
+                return true;
+            }
         }
 
+        return false;
+    }
+
+    private async Task<bool> Authorize(Instance instance, ProcessState nextProcessState)
+    {
         string? taskId = instance.Process.CurrentTask.ElementId;
         string? altinnTaskType = instance.Process.CurrentTask.AltinnTaskType;
 

--- a/src/Storage/Authorization/ProcessAuthorizer.cs
+++ b/src/Storage/Authorization/ProcessAuthorizer.cs
@@ -35,10 +35,12 @@ public class ProcessAuthorizer : IProcessAuthorizer
     }
 
     /// <inheritdoc/>
-    public Task<bool> AuthorizeInstanceLock(Instance instance) => Authorize(instance);
+    public Task<bool> AuthorizeInstanceLock(Instance instance) =>
+        AuthorizeOrFallbackToWrite(instance);
 
     /// <inheritdoc/>
-    public Task<bool> AuthorizeDataElementLock(Instance instance) => Authorize(instance);
+    public Task<bool> AuthorizeDataElementLock(Instance instance) =>
+        AuthorizeOrFallbackToWrite(instance);
 
     /// <inheritdoc/>
     public Task<bool> AuthorizePresentationTextsUpdate(Instance instance) => Authorize(instance);
@@ -65,6 +67,16 @@ public class ProcessAuthorizer : IProcessAuthorizer
             "signing" => ["sign", "write"],
             _ => [taskType],
         };
+    }
+
+    private async Task<bool> AuthorizeOrFallbackToWrite(Instance instance)
+    {
+        if (instance.Process?.CurrentTask is null)
+        {
+            return await _authorizationService.AuthorizeInstanceAction(instance, "write");
+        }
+
+        return await Authorize(instance);
     }
 
     private Task<bool> AuthorizeWithSyncAdapterBypass(Instance instance)

--- a/src/Storage/Authorization/ProcessAuthorizer.cs
+++ b/src/Storage/Authorization/ProcessAuthorizer.cs
@@ -79,10 +79,13 @@ public class ProcessAuthorizer : IProcessAuthorizer
 
     private async Task<bool> Authorize(Instance instance)
     {
-        string? taskId = instance.Process.CurrentTask?.ElementId;
-        string? altinnTaskType = instance.Process.CurrentTask?.AltinnTaskType;
+        string? taskId = instance.Process?.CurrentTask?.ElementId;
+        string? altinnTaskType = instance.Process?.CurrentTask?.AltinnTaskType;
 
-        List<string> actions = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
+        List<string> actions = instance.Process?.CurrentTask is null
+            ? ["write"]
+            : GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
+
         // we don't know if this is an abandon flow, so we include "reject" as a fallback.
         actions.Add("reject");
 

--- a/src/Storage/Authorization/ProcessAuthorizer.cs
+++ b/src/Storage/Authorization/ProcessAuthorizer.cs
@@ -79,10 +79,12 @@ public class ProcessAuthorizer : IProcessAuthorizer
 
     private async Task<bool> Authorize(Instance instance)
     {
-        string? taskId = instance.Process.CurrentTask.ElementId;
-        string? altinnTaskType = instance.Process.CurrentTask.AltinnTaskType;
+        string? taskId = instance.Process.CurrentTask?.ElementId;
+        string? altinnTaskType = instance.Process.CurrentTask?.AltinnTaskType;
 
         List<string> actions = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
+        // we don't know if this is an abandon flow, so we include "reject" as a fallback.
+        actions.Add("reject");
 
         foreach (string action in actions)
         {
@@ -97,16 +99,21 @@ public class ProcessAuthorizer : IProcessAuthorizer
 
     private async Task<bool> Authorize(Instance instance, ProcessState nextProcessState)
     {
+        if (instance.Process?.CurrentTask is null)
+        {
+            return false;
+        }
+
         string? taskId = instance.Process.CurrentTask.ElementId;
         string? altinnTaskType = instance.Process.CurrentTask.AltinnTaskType;
 
-        if (nextProcessState?.CurrentTask?.FlowType == "AbandonCurrentMoveToNext")
+        if (nextProcessState.CurrentTask?.FlowType == "AbandonCurrentMoveToNext")
         {
             return await _authorizationService.AuthorizeInstanceAction(instance, "reject", taskId);
         }
 
         if (
-            nextProcessState?.CurrentTask?.FlowType is not null
+            nextProcessState.CurrentTask?.FlowType is not null
             && nextProcessState.CurrentTask.FlowType != "CompleteCurrentMoveToNext"
         )
         {
@@ -114,13 +121,7 @@ public class ProcessAuthorizer : IProcessAuthorizer
             taskId = nextProcessState.CurrentTask.ElementId;
         }
 
-        // When no nextProcessState is provided (e.g. locking), we don't know if this is an
-        // abandon flow, so we include "reject" as a fallback.
         List<string> actions = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
-        if (nextProcessState is null)
-        {
-            actions.Add("reject");
-        }
 
         foreach (string action in actions)
         {

--- a/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
+++ b/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
@@ -187,12 +187,9 @@ public class ProcessAuthorizerTests
     }
 
     [Fact]
-    public async Task AuthorizeLock_NoCurrentTask_UserLacksWriteAccess_ReturnsFalse()
+    public async Task AuthorizeLock_NoCurrentTask_ReturnsFalse()
     {
         var instance = new Instance { Process = new ProcessState { CurrentTask = null } };
-        _authorizationMock
-            .Setup(a => a.AuthorizeInstanceAction(instance, "write", null))
-            .ReturnsAsync(false);
 
         Assert.False(await CreateSut().AuthorizeDataElementLock(instance));
         Assert.False(await CreateSut().AuthorizeInstanceLock(instance));

--- a/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
+++ b/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
@@ -181,9 +181,24 @@ public class ProcessAuthorizerTests
     }
 
     [Fact]
-    public async Task AuthorizeLock_NoCurrentTask_ReturnsFalse()
+    public async Task AuthorizeLock_NoCurrentTask_UserHasWriteAccess_ReturnsTrue()
     {
         var instance = new Instance { Process = new ProcessState { CurrentTask = null } };
+        _authorizationMock
+            .Setup(a => a.AuthorizeInstanceAction(instance, "write", null))
+            .ReturnsAsync(true);
+
+        Assert.True(await CreateSut().AuthorizeDataElementLock(instance));
+        Assert.True(await CreateSut().AuthorizeInstanceLock(instance));
+    }
+
+    [Fact]
+    public async Task AuthorizeLock_NoCurrentTask_UserLacksWriteAccess_ReturnsFalse()
+    {
+        var instance = new Instance { Process = new ProcessState { CurrentTask = null } };
+        _authorizationMock
+            .Setup(a => a.AuthorizeInstanceAction(instance, "write", null))
+            .ReturnsAsync(false);
 
         Assert.False(await CreateSut().AuthorizeDataElementLock(instance));
         Assert.False(await CreateSut().AuthorizeInstanceLock(instance));

--- a/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
+++ b/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
@@ -35,10 +35,16 @@ public class ProcessAuthorizerTests
             },
         };
 
-    private void SetupAuthorizeAction(string action, string taskId, bool returns) =>
+    private void SetupAuthorizeAction(string action, string taskId, bool returns)
+    {
         _authorizationMock
             .Setup(a => a.AuthorizeInstanceAction(It.IsAny<Instance>(), action, taskId))
             .ReturnsAsync(returns);
+
+        _authorizationMock
+            .Setup(a => a.AuthorizeInstanceAction(It.IsAny<Instance>(), action, null))
+            .ReturnsAsync(returns);
+    }
 
     #region AuthorizeProcessNext
 
@@ -178,18 +184,6 @@ public class ProcessAuthorizerTests
 
         Assert.False(await CreateSut().AuthorizeDataElementLock(instance));
         Assert.False(await CreateSut().AuthorizeInstanceLock(instance));
-    }
-
-    [Fact]
-    public async Task AuthorizeLock_NoCurrentTask_UserHasWriteAccess_ReturnsTrue()
-    {
-        var instance = new Instance { Process = new ProcessState { CurrentTask = null } };
-        _authorizationMock
-            .Setup(a => a.AuthorizeInstanceAction(instance, "write", null))
-            .ReturnsAsync(true);
-
-        Assert.True(await CreateSut().AuthorizeDataElementLock(instance));
-        Assert.True(await CreateSut().AuthorizeInstanceLock(instance));
     }
 
     [Fact]

--- a/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
+++ b/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
@@ -35,16 +35,10 @@ public class ProcessAuthorizerTests
             },
         };
 
-    private void SetupAuthorizeAction(string action, string taskId, bool returns)
-    {
+    private void SetupAuthorizeAction(string action, string taskId, bool returns) =>
         _authorizationMock
             .Setup(a => a.AuthorizeInstanceAction(It.IsAny<Instance>(), action, taskId))
             .ReturnsAsync(returns);
-
-        _authorizationMock
-            .Setup(a => a.AuthorizeInstanceAction(It.IsAny<Instance>(), action, null))
-            .ReturnsAsync(returns);
-    }
 
     #region AuthorizeProcessNext
 

--- a/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
+++ b/test/UnitTest/TestingServices/ProcessAuthorizerTests.cs
@@ -189,6 +189,29 @@ public class ProcessAuthorizerTests
         Assert.False(await CreateSut().AuthorizeInstanceLock(instance));
     }
 
+    [Fact]
+    public async Task AuthorizeLock_NoCurrentTask_UserHasWriteAccess_ReturnsTrue()
+    {
+        var instance = new Instance { Process = new ProcessState { CurrentTask = null } };
+        _authorizationMock
+            .Setup(a => a.AuthorizeInstanceAction(instance, "write", null))
+            .ReturnsAsync(true);
+
+        var sut = CreateSut();
+
+        Assert.True(await sut.AuthorizeInstanceLock(instance));
+        Assert.True(await sut.AuthorizeDataElementLock(instance));
+    }
+
+    [Fact]
+    public async Task AuthorizeLock_NoProcess_ReturnsFalse()
+    {
+        var instance = new Instance { Process = null };
+
+        Assert.False(await CreateSut().AuthorizeDataElementLock(instance));
+        Assert.False(await CreateSut().AuthorizeInstanceLock(instance));
+    }
+
     #endregion
 
     #region AuthorizePresentationTextsUpdate and AuthorizeDataValuesUpdate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Let task be null or whitespace and simply not evaluated in the auth call `DecisionHJelper.cs CreateResourceCategoryU`:
```
        if (!string.IsNullOrWhiteSpace(task))
        {
            xacmlJsonCategory.Attribute.Add(CreateXacmlJsonAttribute("urn:altinn:task", task, "string", "Altinn"));
        }
```

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted authorization fallback so locks now check a fallback action when no current task exists; some lock attempts will now correctly be denied if write access is absent.
  * Process-next authorization now requires an explicit next-state context, improving predictability of authorization outcomes.

* **Tests**
  * Expanded and refined tests for authorization scenarios to cover the new fallback and next-state behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->