### PR TITLE
fix: add graceful shutdown to storage

### DIFF
--- a/src/Storage/Extensions/HostingExtensions.cs
+++ b/src/Storage/Extensions/HostingExtensions.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.Platform.Storage.Extensions;
+
+internal static class HostingExtensions
+{
+    /// <summary>
+    /// Configures host shutdown to coordinate Kubernetes endpoint drain and ASP.NET Core request drain.
+    /// </summary>
+    internal static WebApplicationBuilder UseGracefulShutdown(this WebApplicationBuilder builder)
+    {
+        if (builder.Environment.IsDevelopment())
+        {
+            return builder;
+        }
+
+        var shutdownDelay = TimeSpan.FromSeconds(5);
+        var shutdownTimeout = TimeSpan.FromSeconds(20);
+
+        builder.Services.AddSingleton<IHostLifetime>(sp =>
+            ActivatorUtilities.CreateInstance<AppHostLifetime>(sp, shutdownDelay)
+        );
+
+        builder.Services.Configure<HostOptions>(options =>
+            options.ShutdownTimeout = shutdownTimeout
+        );
+
+        return builder;
+    }
+
+    private sealed class AppHostLifetime(
+        ILogger<AppHostLifetime> logger,
+        IHostEnvironment environment,
+        IHostApplicationLifetime applicationLifetime,
+        TimeSpan delay
+    ) : IHostLifetime, IDisposable
+    {
+        private IDisposable[]? _disposables;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task WaitForStartAsync(CancellationToken cancellationToken)
+        {
+            Debug.Assert(
+                !environment.IsDevelopment(),
+                "We don't need graceful shutdown in development environments"
+            );
+            PosixSignalRegistration? sigint = null;
+            PosixSignalRegistration? sigquit = null;
+            PosixSignalRegistration? sigterm = null;
+            try
+            {
+#pragma warning disable CA2000 // Ownership is transferred to _disposables and disposed in Dispose().
+                sigint = PosixSignalRegistration.Create(PosixSignal.SIGINT, HandleSignal);
+                sigquit = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, HandleSignal);
+                sigterm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, HandleSignal);
+#pragma warning restore CA2000
+                _disposables = [sigint, sigquit, sigterm];
+            }
+            catch
+            {
+                TryDispose(sigint);
+                TryDispose(sigquit);
+                TryDispose(sigterm);
+                throw;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void HandleSignal(PosixSignalContext ctx)
+        {
+            logger.LogInformation(
+                "Received shutdown signal: {Signal}, delaying shutdown",
+                ctx.Signal
+            );
+            ctx.Cancel = true;
+
+            _ = Task.Delay(delay)
+                .ContinueWith(
+                    _ =>
+                    {
+                        logger.LogInformation("Starting host shutdown...");
+                        applicationLifetime.StopApplication();
+                    },
+                    TaskScheduler.Default
+                );
+        }
+
+        public void Dispose()
+        {
+            foreach (var disposable in _disposables ?? [])
+            {
+                TryDispose(disposable);
+            }
+        }
+
+        private void TryDispose(IDisposable? disposable)
+        {
+            try
+            {
+                disposable?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Error during disposal of {Type}",
+                    disposable?.GetType().FullName
+                );
+            }
+        }
+    }
+}

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -429,24 +429,27 @@ void ConfigureWolverine(IServiceCollection services, IConfiguration config)
             // Force wolverine to use bus for sending messages (not handle messages internal)
             opts.Policies.DisableConventionalLocalRouting();
 
-            // Azure Service Bus transport
-            opts.UseAzureServiceBus(wolverineSettings.ServiceBusConnectionString)
-                // Use custom mapper to set deduplication id on outgoing messages
-                .ConfigureSenders(s =>
-                {
-                    s.CustomizeOutgoingMessagesOfType<SyncInstanceToDialogportenCommand>(
-                        (envelope, cmd) =>
-                        {
-                            envelope.Id = Guid.NewGuid();
-                        }
-                    );
-                })
-                // Let Wolverine try to initialize any missing queues on the first usage at runtime
-                .AutoProvision();
+            if (wolverineSettings.EnableSending)
+            {
+                // Azure Service Bus transport
+                opts.UseAzureServiceBus(wolverineSettings.ServiceBusConnectionString)
+                    // Use custom mapper to set deduplication id on outgoing messages
+                    .ConfigureSenders(s =>
+                    {
+                        s.CustomizeOutgoingMessagesOfType<SyncInstanceToDialogportenCommand>(
+                            (envelope, cmd) =>
+                            {
+                                envelope.Id = Guid.NewGuid();
+                            }
+                        );
+                    })
+                    // Let Wolverine try to initialize any missing queues on the first usage at runtime
+                    .AutoProvision();
 
-            // Publish CreateOrderCommand to ASB queue
-            opts.PublishMessage<SyncInstanceToDialogportenCommand>()
-                .ToAzureServiceBusQueue("altinn.dialogportenadapter.webapi");
+                // Publish CreateOrderCommand to ASB queue
+                opts.PublishMessage<SyncInstanceToDialogportenCommand>()
+                    .ToAzureServiceBusQueue("altinn.dialogportenadapter.webapi");
+            }
         }
         else
         {

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -17,6 +17,7 @@ using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Clients;
 using Altinn.Platform.Storage.Configuration;
+using Altinn.Platform.Storage.Extensions;
 using Altinn.Platform.Storage.Filters;
 using Altinn.Platform.Storage.Health;
 using Altinn.Platform.Storage.Helpers;
@@ -60,6 +61,8 @@ var builder = WebApplication.CreateBuilder(args);
 ConfigureWebHostCreationLogging();
 
 await SetConfigurationProviders(builder.Configuration, builder.Environment.IsDevelopment());
+
+builder.UseGracefulShutdown();
 
 ConfigureApplicationLogging(builder.Logging);
 

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -429,27 +429,24 @@ void ConfigureWolverine(IServiceCollection services, IConfiguration config)
             // Force wolverine to use bus for sending messages (not handle messages internal)
             opts.Policies.DisableConventionalLocalRouting();
 
-            if (wolverineSettings.EnableSending)
-            {
-                // Azure Service Bus transport
-                opts.UseAzureServiceBus(wolverineSettings.ServiceBusConnectionString)
-                    // Use custom mapper to set deduplication id on outgoing messages
-                    .ConfigureSenders(s =>
-                    {
-                        s.CustomizeOutgoingMessagesOfType<SyncInstanceToDialogportenCommand>(
-                            (envelope, cmd) =>
-                            {
-                                envelope.Id = Guid.NewGuid();
-                            }
-                        );
-                    })
-                    // Let Wolverine try to initialize any missing queues on the first usage at runtime
-                    .AutoProvision();
+            // Azure Service Bus transport
+            opts.UseAzureServiceBus(wolverineSettings.ServiceBusConnectionString)
+                // Use custom mapper to set deduplication id on outgoing messages
+                .ConfigureSenders(s =>
+                {
+                    s.CustomizeOutgoingMessagesOfType<SyncInstanceToDialogportenCommand>(
+                        (envelope, cmd) =>
+                        {
+                            envelope.Id = Guid.NewGuid();
+                        }
+                    );
+                })
+                // Let Wolverine try to initialize any missing queues on the first usage at runtime
+                .AutoProvision();
 
-                // Publish CreateOrderCommand to ASB queue
-                opts.PublishMessage<SyncInstanceToDialogportenCommand>()
-                    .ToAzureServiceBusQueue("altinn.dialogportenadapter.webapi");
-            }
+            // Publish CreateOrderCommand to ASB queue
+            opts.PublishMessage<SyncInstanceToDialogportenCommand>()
+                .ToAzureServiceBusQueue("altinn.dialogportenadapter.webapi");
         }
         else
         {

--- a/src/Storage/Services/OutboxService.cs
+++ b/src/Storage/Services/OutboxService.cs
@@ -164,6 +164,9 @@ public class OutboxService(
     /// </remarks>
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
+        // Let BackgroundService cancel ExecuteAsync and wait for the polling loop to stop before releasing the lease.
+        await base.StopAsync(cancellationToken);
+
         using var scope = serviceProvider.CreateScope();
         var outbox = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
         await outbox.ReleaseLeaseAsync(_outboxResource, _podId);

--- a/src/Storage/Services/OutboxService.cs
+++ b/src/Storage/Services/OutboxService.cs
@@ -164,12 +164,17 @@ public class OutboxService(
     /// </remarks>
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
-        // Let BackgroundService cancel ExecuteAsync and wait for the polling loop to stop before releasing the lease.
-        await base.StopAsync(cancellationToken);
-
-        using var scope = serviceProvider.CreateScope();
-        var outbox = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
-        await outbox.ReleaseLeaseAsync(_outboxResource, _podId);
-        _logger.LogInformation("OutboxService with id {PodId} is shutting down", _podId);
+        try
+        {
+            // Let BackgroundService cancel ExecuteAsync and wait for the polling loop to stop before releasing the lease.
+            await base.StopAsync(cancellationToken);
+        }
+        finally
+        {
+            using var scope = serviceProvider.CreateScope();
+            var outbox = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
+            await outbox.ReleaseLeaseAsync(_outboxResource, _podId);
+            _logger.LogInformation("OutboxService with id {PodId} is shutting down", _podId);
+        }
     }
 }

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -56,6 +56,7 @@
       "System": "Warning",
       "Microsoft": "Warning",
       "Npgsql": "Information",
+      "Altinn.Platform.Storage.Extensions.HostingExtensions": "Information",
       "Altinn.Platform.Storage.Controllers.CleanupController": "Information",
       "Altinn.Platform.Storage.Controllers.MessageBoxInstancesController": "Information",
       "Altinn.Platform.Storage.Services.OutboxService": "Information"

--- a/test/UnitTest/Extensions/HostingExtensionsTests.cs
+++ b/test/UnitTest/Extensions/HostingExtensionsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using Altinn.Platform.Storage.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Altinn.Platform.Storage.UnitTest.Extensions;
+
+public class HostingExtensionsTests
+{
+    [Fact]
+    public void UseGracefulShutdown_Production_ConfiguresHostLifetimeAndShutdownTimeout()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = Environments.Production }
+        );
+
+        builder.UseGracefulShutdown();
+
+        using ServiceProvider services = builder.Services.BuildServiceProvider();
+        var hostLifetime = services.GetRequiredService<IHostLifetime>();
+        var hostOptions = services.GetRequiredService<IOptions<HostOptions>>().Value;
+
+        Assert.Equal("AppHostLifetime", hostLifetime.GetType().Name);
+        Assert.Equal(TimeSpan.FromSeconds(20), hostOptions.ShutdownTimeout);
+    }
+
+    [Fact]
+    public void UseGracefulShutdown_Development_DoesNotReplaceHostLifetime()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = Environments.Development }
+        );
+        int registrationsBefore = builder.Services.Count(descriptor =>
+            descriptor.ServiceType == typeof(IHostLifetime)
+        );
+
+        builder.UseGracefulShutdown();
+
+        int registrationsAfter = builder.Services.Count(descriptor =>
+            descriptor.ServiceType == typeof(IHostLifetime)
+        );
+        Assert.Equal(registrationsBefore, registrationsAfter);
+    }
+}

--- a/test/UnitTest/TestingServices/OutboxServiceTests.cs
+++ b/test/UnitTest/TestingServices/OutboxServiceTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.Platform.Storage.Configuration;
+using Altinn.Platform.Storage.Repository;
+using Altinn.Platform.Storage.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Altinn.Platform.Storage.UnitTest.TestingServices;
+
+public class OutboxServiceTests
+{
+    [Fact]
+    public async Task StopAsync_CancelsBackgroundExecutionAndReleasesLease()
+    {
+        var leasePollStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var outbox = new Mock<IOutboxRepository>(MockBehavior.Strict);
+        outbox
+            .Setup(repository =>
+                repository.TryAcquireLeaseAsync("outbox", It.IsAny<Guid>(), It.IsAny<DateTime>())
+            )
+            .Callback(() => leasePollStarted.SetResult())
+            .ReturnsAsync(false);
+        outbox
+            .Setup(repository => repository.ReleaseLeaseAsync("outbox", It.IsAny<Guid>()))
+            .ReturnsAsync(true);
+
+        await using ServiceProvider services = new ServiceCollection()
+            .AddSingleton(outbox.Object)
+            .BuildServiceProvider();
+
+        var service = new OutboxService(
+            NullLogger<OutboxService>.Instance,
+            services,
+            Options.Create(
+                new WolverineSettings
+                {
+                    EnableSending = true,
+                    TryGettingPollMasterIntervalSecs = 60,
+                    LeaseSecs = 60,
+                }
+            )
+        );
+
+        await service.StartAsync(CancellationToken.None);
+        await leasePollStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await service.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(service.ExecuteTask);
+        Assert.True(service.ExecuteTask.IsCompleted);
+        outbox.Verify(
+            repository => repository.ReleaseLeaseAsync("outbox", It.IsAny<Guid>()),
+            Times.Once
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add Kubernetes-oriented graceful shutdown handling to Storage with a 5s SIGTERM delay and 20s ASP.NET Core shutdown timeout.
- Wire the graceful shutdown setup into `Program.cs` outside development environments.
- Fix `OutboxService.StopAsync` so `BackgroundService` cancels and waits for the polling loop before releasing the outbox lease.
- Add focused unit tests for the graceful shutdown registration and outbox shutdown behavior.

## Why
Storage runs in Kubernetes as a DaemonSet and should coordinate SIGTERM handling with endpoint/routing drain and ASP.NET Core request drain, like the existing Altinn .NET shutdown pattern. The outbox service also overrode `StopAsync` without calling the base implementation, so the background execution loop was not being cancelled by the inherited `BackgroundService` shutdown path.

## Testing
- `dotnet test test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj --filter "FullyQualifiedName~HostingExtensionsTests|FullyQualifiedName~OutboxServiceTests" --logger "console;verbosity=minimal"`
- `dotnet csharpier check src/Storage/Program.cs src/Storage/Services/OutboxService.cs src/Storage/Extensions/HostingExtensions.cs test/UnitTest/Extensions/HostingExtensionsTests.cs test/UnitTest/TestingServices/OutboxServiceTests.cs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved production host shutdown by handling termination signals and coordinating shutdown timing.
* **Bug Fixes**
  * Updated outbox service shutdown to stop background processing before releasing the outbox lease, ensuring consistent cleanup even if shutdown encounters errors.
* **Tests**
  * Added unit tests covering graceful shutdown differences between production and development, plus verification that outbox shutdown cancels background work and releases the lease.
* **Chores**
  * Updated CI to use a PostgreSQL service container and a newer .NET SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->