### PR TITLE
ci: align fork build workflow

### DIFF
--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - '.github/workflows/build-and-analyze-fork.yml'
       - 'src/**'
       - 'test/Altinn.Platform.Storage.Interface.Tests/**'
       - 'test/UnitTest/**'
@@ -15,66 +16,56 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    services:
+      postgres:
+        image: postgres:16@sha256:4b7183ac05f8ef417db21fd72d71047a4238340c261d3cc3ddb6d579ab5071ae
+        env:
+          PGHOST: localhost
+          POSTGRES_USER: platform_storage_admin
+          POSTGRES_PASSWORD: Password
+          POSTGRES_DB: storagedb
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
-      - name: Set inotify watchers
-        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      - name: Set inotify instances
-        run: echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: |
-            8.0.x
+            9.0.x
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - name: dotnet build
-        run: dotnet build Altinn.Platform.Storage.slnx -v m
-
-      - name: dotnet test
-        run: dotnet test Altinn.Platform.Storage.slnx --results-directory TestResults/ --collect:"XPlat Code Coverage" -v m
-
-      - name: Generate coverage results
+      - name: Setup PostgreSQL
         run: |
-          dotnet tool install --global dotnet-reportgenerator-globaltool
-          reportgenerator -reports:TestResults/**/coverage.cobertura.xml -targetdir:TestResults/Output/CoverageReport -reporttypes:Cobertura
+          chmod +x dbsetup.sh
+          ./dbsetup.sh
+      - name: Restart database to enable config changes
+        run: |
+          docker ps --quiet | xargs --no-run-if-empty docker restart
+      - name: Build & Test
+        run: |
+          dotnet build Altinn.Platform.Storage.slnx -v q
 
-      - name: Archive code coverage results
+          dotnet test Altinn.Platform.Storage.slnx \
+          -v q \
+          --collect:"XPlat Code Coverage" /p:Exclude="**/Program.cs" \
+          --results-directory TestResults/ \
+          --logger "trx;" \
+          --configuration release \
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: code-coverage-report
-          path: TestResults/Output/CoverageReport/
-
-  code-coverage:
-    if: github.actor == 'dependabot[bot]' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
-    name: Report code coverage
-    runs-on: ubuntu-latest
-    permissions: {}
-    needs: test
-    steps:
-      - name: Download Coverage Results
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: code-coverage-report
-          path: dist/
-      - name: Create Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
-        with:
-          filename: dist/Cobertura.xml
-          badge: true
-          fail_below_min: true
-          format: markdown
-          hide_branch_rate: false
-          hide_complexity: true
-          indicators: true
-          output: both
-          thresholds: '60 80'
-
-     # Step disabled until workaround available for commenting PR
-     # - name: Add Coverage PR Comment
-     #   uses: marocchino/sticky-pull-request-comment@v2
-     #   with:
-     #     recreate: true
-     #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-     #     path: code-coverage-results.md
+          name: TestResults
+          path: '**/TestResults/*.trx'

--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -52,20 +52,10 @@ jobs:
           ./dbsetup.sh
       - name: Restart database to enable config changes
         run: |
-          docker restart "${{ job.services.postgres.id }}"
-          for _ in {1..30}; do
-            if pg_isready -h localhost -p 5432 -U platform_storage_admin -d storagedb; then
-              exit 0
-            fi
-
-            sleep 1
-          done
-
-          docker logs "${{ job.services.postgres.id }}"
-          exit 1
+          docker restart $(docker ps -q)
       - name: Build & Test
         run: |
-          dotnet build Altinn.Platform.Storage.slnx -v q --configuration release
+          dotnet build Altinn.Platform.Storage.slnx -v q
 
           dotnet test Altinn.Platform.Storage.slnx \
           -v q \
@@ -73,7 +63,6 @@ jobs:
           --results-directory TestResults/ \
           --logger "trx;" \
           --configuration release \
-          --no-build \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - name: Upload test results
         if: always()

--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -45,16 +45,27 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: Setup PostgreSQL
         run: |
           chmod +x dbsetup.sh
           ./dbsetup.sh
       - name: Restart database to enable config changes
         run: |
-          docker ps --quiet | xargs --no-run-if-empty docker restart
+          docker restart "${{ job.services.postgres.id }}"
+          for _ in {1..30}; do
+            if pg_isready -h localhost -p 5432 -U platform_storage_admin -d storagedb; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          docker logs "${{ job.services.postgres.id }}"
+          exit 1
       - name: Build & Test
         run: |
-          dotnet build Altinn.Platform.Storage.slnx -v q
+          dotnet build Altinn.Platform.Storage.slnx -v q --configuration release
 
           dotnet test Altinn.Platform.Storage.slnx \
           -v q \
@@ -62,6 +73,7 @@ jobs:
           --results-directory TestResults/ \
           --logger "trx;" \
           --configuration release \
+          --no-build \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- Align the fork PR build workflow with the non-fork build/test flow where no secrets or write permissions are needed.
- Add the same PostgreSQL service/setup and .NET 9 SDK selection used by the main build workflow.
- Remove the fork-only coverage summary gate and keep only test result artifact upload.

## Context
This addresses the workflow parity part of #567 separately from #1011, per review feedback. The fork workflow still avoids SonarCloud and check-result publishing because those require secrets/write permissions.

## Testing
- `actionlint .github/workflows/build-and-analyze-fork.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved database service initialization, health monitoring, and configuration management.
  * Updated build and test infrastructure with refined execution tooling and optimized test result collection methods for improved workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->