### PR TITLE
fix: reduce storage database log noise

### DIFF
--- a/src/Storage/Configuration/PostgreSqlSettings.cs
+++ b/src/Storage/Configuration/PostgreSqlSettings.cs
@@ -20,5 +20,5 @@ public class PostgreSqlSettings
     /// <summary>
     /// Gets or sets a value indicating whether to include parameter values in logging/tracing.
     /// </summary>
-    public bool LogParameters { get; set; } = true;
+    public bool LogParameters { get; set; } = false;
 }

--- a/src/Storage/appsettings.Development.json
+++ b/src/Storage/appsettings.Development.json
@@ -3,7 +3,11 @@
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",
-      "Microsoft": "Information"
+      "Microsoft": "Information",
+      "Npgsql": "Information"
     }
+  },
+  "PostgreSqlSettings": {
+    "LogParameters": true
   }
 }

--- a/src/Storage/appsettings.Production.json
+++ b/src/Storage/appsettings.Production.json
@@ -4,7 +4,7 @@
       "Default": "Warning",
       "System": "Warning",
       "Microsoft": "Warning",
-      "Npgsql": "Information",
+      "Npgsql": "Warning",
       "Altinn.Platform.Storage.Controllers.CleanupController": "Information",
       "Altinn.Platform.Storage.Controllers.MessageBoxInstancesController": "Information",
       "Altinn.Platform.Storage.Services.OutboxService": "Information"

--- a/src/Storage/appsettings.Staging.json
+++ b/src/Storage/appsettings.Staging.json
@@ -4,7 +4,7 @@
       "Default": "Warning",
       "System": "Warning",
       "Microsoft": "Warning",
-      "Npgsql": "Information",
+      "Npgsql": "Warning",
       "Altinn.Platform.Storage.Controllers.CleanupController": "Information",
       "Altinn.Platform.Storage.Controllers.MessageBoxInstancesController": "Information",
       "Altinn.Platform.Storage.Services.OutboxService": "Information"

--- a/src/Storage/appsettings.json
+++ b/src/Storage/appsettings.json
@@ -4,7 +4,8 @@
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_storage_admin;Password={0};Database=storagedb",
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_storage;Password={0};Database=storagedb;Include Error Detail=True",
     "StorageDbAdminPwd": "Password",
-    "StorageDbPwd": "Password"
+    "StorageDbPwd": "Password",
+    "LogParameters": false
   },
   "AllowedHosts": "*",
   "AzureStorageConfiguration": {
@@ -55,7 +56,7 @@
       "Default": "Warning",
       "System": "Warning",
       "Microsoft": "Warning",
-      "Npgsql": "Information",
+      "Npgsql": "Warning",
       "Altinn.Platform.Storage.Extensions.HostingExtensions": "Information",
       "Altinn.Platform.Storage.Controllers.CleanupController": "Information",
       "Altinn.Platform.Storage.Controllers.MessageBoxInstancesController": "Information",


### PR DESCRIPTION
## What
- Lower Npgsql logging from Information to Warning in default, staging, and production settings.
- Make PostgreSQL parameter logging opt-in by default.
- Keep verbose Npgsql logging and parameter logging enabled in Development.

## Why
TT02/production logs contain high-volume `Npgsql.Command[2001]` entries for routine database commands. These are log records, while database spans are already emitted through OpenTelemetry/Npgsql instrumentation.

## Testing
- `dotnet build src/Storage/Altinn.Platform.Storage.csproj --no-restore`
- JSON appsettings parse check

`dotnet test test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj --no-build` was attempted locally, but this environment has no PostgreSQL instance on `127.0.0.1:5432`, so host-starting tests fail during Yuniql startup with connection refused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * PostgreSQL parameter logging is now disabled by default to reduce data exposure in logs and traces.
  * Database logging verbosity reduced for production and staging environments to optimize performance.
  * Development environment maintains detailed database logging for debugging purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->