### PR TITLE
chore: extend graceful shutdown

### DIFF
--- a/src/Storage/Extensions/HostingExtensions.cs
+++ b/src/Storage/Extensions/HostingExtensions.cs
@@ -23,7 +23,7 @@ internal static class HostingExtensions
         }
 
         var shutdownDelay = TimeSpan.FromSeconds(5);
-        var shutdownTimeout = TimeSpan.FromSeconds(20);
+        var shutdownTimeout = TimeSpan.FromSeconds(50);
 
         builder.Services.AddSingleton<IHostLifetime>(sp =>
             ActivatorUtilities.CreateInstance<AppHostLifetime>(sp, shutdownDelay)

--- a/test/UnitTest/Extensions/HostingExtensionsTests.cs
+++ b/test/UnitTest/Extensions/HostingExtensionsTests.cs
@@ -25,7 +25,7 @@ public class HostingExtensionsTests
         var hostOptions = services.GetRequiredService<IOptions<HostOptions>>().Value;
 
         Assert.Equal("AppHostLifetime", hostLifetime.GetType().Name);
-        Assert.Equal(TimeSpan.FromSeconds(20), hostOptions.ShutdownTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(50), hostOptions.ShutdownTimeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

we get some longer-running requests here so extending the request draining timeout to match terminationGracePeriodSeconds of 60 in the k8s manifest

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the application’s shutdown timeout, giving it more time to close gracefully and reducing the chance of abrupt termination during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->