### PR TITLE
feat: add datetime field to metrics record

### DIFF
--- a/src/Storage/Models/Metrics/DailyInstanceMetricsRecord.cs
+++ b/src/Storage/Models/Metrics/DailyInstanceMetricsRecord.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Storage.Models.Metrics;
@@ -37,4 +38,9 @@ public record DailyInstanceMetricsRecord
     /// </summary>
     [JsonPropertyName("resourceTitle")]
     public string ResourceTitle { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the date and time of the record.
+    /// </summary>
+    public DateTime DateTime { get; set; }
 }

--- a/src/Storage/Models/Metrics/DailyInstanceMetricsRecord.cs
+++ b/src/Storage/Models/Metrics/DailyInstanceMetricsRecord.cs
@@ -42,5 +42,6 @@ public record DailyInstanceMetricsRecord
     /// <summary>
     /// Gets or sets the date and time of the record.
     /// </summary>
+    [JsonPropertyName("dateTime")]
     public DateTime DateTime { get; set; }
 }

--- a/src/Storage/Repository/PgMetricsRepository.cs
+++ b/src/Storage/Repository/PgMetricsRepository.cs
@@ -35,6 +35,7 @@ public class PgMetricsRepository(NpgsqlDataSource dataSource) : IMetricsReposito
         {
             DailyInstanceMetricsRecord instanceRow = await GenerateInstanceMetricsRecord(
                 reader,
+                dateTime,
                 cancellationToken
             );
             metrics.Metrics.Add(instanceRow);
@@ -45,6 +46,7 @@ public class PgMetricsRepository(NpgsqlDataSource dataSource) : IMetricsReposito
 
     private static async Task<DailyInstanceMetricsRecord> GenerateInstanceMetricsRecord(
         NpgsqlDataReader reader,
+        DateTime dateTime,
         CancellationToken cancellationToken
     )
     {
@@ -67,6 +69,7 @@ public class PgMetricsRepository(NpgsqlDataSource dataSource) : IMetricsReposito
                 "completed_instances",
                 cancellationToken
             ),
+            DateTime = dateTime,
         };
     }
 

--- a/src/Storage/Services/MetricsService.cs
+++ b/src/Storage/Services/MetricsService.cs
@@ -56,7 +56,7 @@ public class MetricsService : IMetricsService
         CancellationToken cancellationToken
     )
     {
-        DateTime date = DateTime.UtcNow.AddDays(-_daysOffsetForDailyMetrics);
+        DateTime date = DateTime.UtcNow.Date.AddDays(-_daysOffsetForDailyMetrics);
 
         var metrics = await _metricsRepository.GetDailyInstanceMetrics(date, cancellationToken);
         try

--- a/test/UnitTest/TestingServices/MetricsServiceTests.cs
+++ b/test/UnitTest/TestingServices/MetricsServiceTests.cs
@@ -79,6 +79,7 @@ public class MetricsServiceTests
         Assert.Equal(record.ResourceTitle, response.Metrics[0].ResourceTitle);
         Assert.Equal(record.ServiceOwnerCode, response.Metrics[0].ServiceOwnerCode);
         Assert.Equal(orgNr, response.Metrics[0].ServiceOwnerOrgNumber);
+        Assert.Equal(record.DateTime, response.Metrics[0].DateTime);
 
         metricsRepositoryMock.Verify(
             e => e.GetDailyInstanceMetrics(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
@@ -214,6 +215,7 @@ public class MetricsServiceTests
             ResourceTitle = "Test",
             ServiceOwnerCode = "digdir",
             ServiceOwnerOrgNumber = "0",
+            DateTime = new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc),
         };
         return new DailyMetrics<DailyInstanceMetricsRecord>
         {


### PR DESCRIPTION
## Description
Metrics endpoint, `DateTime` field has been added to the metrics record.
The timestamp portion of the datetime is set to midnight, `00:00:00:0000000`

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/18654

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily instance metrics now include the correct timestamp.
  * Date-based metric retrieval now targets the correct UTC day before applying the configured offset, improving accuracy around UTC boundaries.

* **Tests**
  * Added assertions to verify returned metrics contain the expected date and time.
  * Updated shared test data to explicitly set the metric timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->