### PR TITLE
chore: add paths for `dotnet-format.yml` workflow trigger

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,6 +2,11 @@ name: Verify dotnet format
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/dotnet-format.yml'
+      - 'src/**'
+      - 'test/Altinn.Platform.Storage.Interface.Tests/**'
+      - 'test/UnitTest/**'
 permissions:
   contents: read
 


### PR DESCRIPTION
## Description
Add paths containing C# code for github workflow, should no longer trigger on any/all PRs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited formatting workflow runs to relevant source, test, and workflow changes.
  * Improved CI efficiency by avoiding unnecessary workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->