### PR TITLE
chore: upgrade .NET SDK to v10.0

### DIFF
--- a/.github/workflows/build-and-analyze-fork.yml
+++ b/.github/workflows/build-and-analyze-fork.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
-            9.0.x
+            10.0.x
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
-            9.0.x
+            10.0.x
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Setup .NET 9.0.* SDK
+      - name: Setup .NET 10.0.* SDK
         if: matrix.language == 'csharp'
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
-            9.0.x
+            10.0.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Install csharpier
       run: dotnet tool restore
     - name: Run csharpier

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
-            9.0.x
+            10.0.x
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: |
-            9.0.x
+            10.0.x
       - name: Install deps
         run: |
           cd src/Storage.Interface

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.24@sha256:011500266c639eb5f4c585cb26661337a58108e35164aa292660a154a53878eb AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.24@sha256:979da27fc87dc255f4675b7642556cdcba9307459f8891f85f3cc26edcd7e766 AS build
 
 COPY src/Storage ./Storage
 COPY src/DbTools ./DbTools
@@ -8,14 +8,14 @@ WORKDIR DbTools/
 RUN dotnet build ./DbTools.csproj -c Release -o /app_tools
 
 # Comment in the following line for local development
-# RUN mkdir -p /DbTools/bin/Debug/net9.0 && cp /app_tools/DbTools /DbTools/bin/Debug/net9.0/DbTools
+# RUN mkdir -p /DbTools/bin/Debug/net10.0 && cp /app_tools/DbTools /DbTools/bin/Debug/net10.0/DbTools
 
 WORKDIR ../Storage/
 
 RUN dotnet build ./Altinn.Platform.Storage.csproj -c Release -o /app_output
 RUN dotnet publish ./Altinn.Platform.Storage.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine3.24@sha256:50f2dccb17be5f2c7e75814ca70e6c913a969b503214fe978a82301a450a63cb AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.24@sha256:eb7c0c9ef04479bfff191036f6b8959a7d6bac983bd7160c6b8b84b20d3ad0e7 AS final
 EXPOSE 5010
 WORKDIR /app
 COPY --from=build /app_output .

--- a/src/DbTools/DbTools.csproj
+++ b/src/DbTools/DbTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
-    <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
+    <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="PDFsharp" Version="6.2.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="8.1.4" />

--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>8c2ac76a-d8b4-498d-867a-0ac18639f275</UserSecretsId>
@@ -25,9 +25,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="8.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="Npgsql" Version="9.0.5" />
-    <PackageReference Include="Npgsql.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="Npgsql.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
@@ -35,7 +34,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.5" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.3" />
     <PackageReference Include="WolverineFx" Version="5.39.5" />
     <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
     <PackageReference Include="Parquet.Net" Version="5.6.1" />

--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
     <PackageReference Include="PDFsharp" Version="6.2.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Npgsql.DependencyInjection" Version="10.0.3" />

--- a/src/Storage/Program.cs
+++ b/src/Storage/Program.cs
@@ -32,14 +32,13 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Npgsql;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -389,22 +388,16 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
                 Type = SecuritySchemeType.ApiKey,
             }
         );
-        c.AddSecurityRequirement(
-            new OpenApiSecurityRequirement
+        c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+        {
             {
-                {
-                    new OpenApiSecurityScheme
-                    {
-                        Reference = new OpenApiReference
-                        {
-                            Id = JwtCookieDefaults.AuthenticationScheme,
-                            Type = ReferenceType.SecurityScheme,
-                        },
-                    },
-                    Array.Empty<string>()
-                },
-            }
-        );
+                new OpenApiSecuritySchemeReference(
+                    JwtCookieDefaults.AuthenticationScheme,
+                    document
+                ),
+                []
+            },
+        });
         try
         {
             c.IncludeXmlComments(GetXmlCommentsPathForControllers());

--- a/test/Altinn.Platform.Storage.Interface.Tests/Altinn.Platform.Storage.Interface.Tests.csproj
+++ b/test/Altinn.Platform.Storage.Interface.Tests/Altinn.Platform.Storage.Interface.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
+++ b/test/UnitTest/Altinn.Platform.Storage.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <UserSecretsId>719eaaa3-a93f-43e9-bc80-86e01719b323</UserSecretsId>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Description
Upgrade project to .NET V10.

Removed a package which is no longer in use, `System.Text.RegularExpressions`, its now part of dotnet.
Bumping `JWTCookieAuthentication` to major version `4.0.4`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Retargeted the application and test projects to **.NET 10**.
  * Updated CI workflows (build/test/analyze, CodeQL, formatting, and publishing/release) to use the **.NET 10 SDK**.
  * Updated the container build/runtime images to **.NET 10**.
* **Dependency Updates**
  * Upgraded authentication, Swagger/OpenAPI, and PostgreSQL-related packages for **.NET 10** compatibility.
* **API Documentation**
  * Updated Swagger security configuration to align with the JWT cookie authentication scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->