### PR TITLE
chore: remove AT24 from use-case-ATX.yml

### DIFF
--- a/.github/workflows/use-case-ATX.yml
+++ b/.github/workflows/use-case-ATX.yml
@@ -13,7 +13,6 @@ jobs:
     outputs:
       failed-AT22: ${{ steps.set-failure.outputs.AT22 }}
       failed-AT23: ${{ steps.set-failure.outputs.AT23 }}
-      #failed-AT24: ${{ steps.set-failure.outputs.AT24 }}
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-latest
     permissions:
@@ -90,8 +89,6 @@ jobs:
             output: failed-AT22
           - environment: AT23
             output: failed-AT23
-          #- environment: AT24
-          #  output: failed-AT24
     runs-on: ubuntu-latest
     steps:
       - name: Send notification


### PR DESCRIPTION
## Description
Remove AT24 from use-case tests permanently, it was commented out before.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test workflow tracking to cover only the active AT22 and AT23 environments.
  * Removed obsolete AT24 configuration references while preserving existing test execution and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->