### PR TITLE
fix: reuse single connection pool in unit tests

### DIFF
--- a/test/UnitTest/Extensions/ServiceCollectionExtensions.cs
+++ b/test/UnitTest/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.UnitTest.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace Altinn.Platform.Storage.UnitTest.Extensions;
 
@@ -32,6 +33,18 @@ public static class ServiceCollectionExtensions
 
         string connectionString = string.Format(settings.ConnectionString, settings.StorageDbPwd);
 
+        services.AddNpgsqlDataSource(connectionString, builder => builder.EnableDynamicJson());
+
+        return services.AddRepositoryImplementations();
+    }
+
+    /// <summary>
+    /// Registers the repository implementations, expecting an <see cref="NpgsqlDataSource"/> to be
+    /// registered separately so callers can share one data source instead of opening another pool.
+    /// </summary>
+    /// <param name="services">service collection.</param>
+    public static IServiceCollection AddRepositoryImplementations(this IServiceCollection services)
+    {
         return services
             .AddSingleton<IApplicationRepository, PgApplicationRepository>()
             .AddSingleton<ITextRepository, PgTextRepository>()
@@ -41,7 +54,6 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IInstanceAndEventsRepository, PgInstanceAndEventsRepository>()
             .AddSingleton<IBlobRepository, BlobRepository>()
             .AddSingleton<IOutboxRepository, PgOutboxRepository>()
-            .AddSingleton<IInstanceLockRepository, PgInstanceLockRepository>()
-            .AddNpgsqlDataSource(connectionString, builder => builder.EnableDynamicJson());
+            .AddSingleton<IInstanceLockRepository, PgInstanceLockRepository>();
     }
 }

--- a/test/UnitTest/TestingRepositories/OutboxTests.cs
+++ b/test/UnitTest/TestingRepositories/OutboxTests.cs
@@ -10,7 +10,6 @@ using Altinn.Platform.Storage.Messages;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.UnitTest.Extensions;
 using Altinn.Platform.Storage.UnitTest.Utils;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -207,12 +206,12 @@ public class OutboxTests
 
         var config = builder.Build();
 
-        WebApplication.CreateBuilder().Build().SetUpPostgreSql(true, config);
-
         IServiceCollection services = new ServiceCollection();
 
         services.AddLogging();
-        services.AddPostgresRepositories(config);
+
+        services.AddSingleton(ServiceUtil.GetSharedDataSource());
+        services.AddRepositoryImplementations();
         services.AddMemoryCache();
 
         Mock<IHttpContextAccessor> httpContextAccessor = new Mock<IHttpContextAccessor>(

--- a/test/UnitTest/TestingRepositories/OutboxTests.cs
+++ b/test/UnitTest/TestingRepositories/OutboxTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Altinn.Platform.Storage.UnitTest.TestingRepositories;
 
+[Collection("StoragePostgreSQL")]
 public class OutboxTests
 {
     public OutboxTests()
@@ -189,9 +190,7 @@ public class OutboxTests
 
     private static NpgsqlConnection GetConnection()
     {
-        NpgsqlDataSource dataSource = (NpgsqlDataSource)
-            ServiceUtil.GetServices([typeof(NpgsqlDataSource)])[0]!;
-        return dataSource.OpenConnection();
+        return ServiceUtil.GetSharedDataSource().OpenConnection();
     }
 
     private static List<object> GetServices(

--- a/test/UnitTest/TestingRepositories/OutboxTests.cs
+++ b/test/UnitTest/TestingRepositories/OutboxTests.cs
@@ -54,7 +54,8 @@ public class OutboxTests
     {
         var cmdObj = CreateCommand(Guid.NewGuid().ToString());
 
-        await GetRepo().Insert(cmdObj, GetConnection());
+        await using var connection = GetConnection();
+        await GetRepo().Insert(cmdObj, connection);
 
         string sql = $"select count(*) from storage.outbox";
         int count = await PostgresUtil.RunCountQuery(sql);
@@ -69,8 +70,10 @@ public class OutboxTests
         var first = CreateCommand(sharedId, created: now, evt: InstanceEventType.Saved);
         var second = CreateCommand(sharedId, created: now, evt: InstanceEventType.Deleted);
 
-        await GetRepo().Insert(first, GetConnection());
-        await GetRepo().Insert(second, GetConnection());
+        var repo = GetRepo();
+        await using var connection = GetConnection();
+        await repo.Insert(first, connection);
+        await repo.Insert(second, connection);
 
         string sql = $"select count(*) from storage.outbox";
         int count = await PostgresUtil.RunCountQuery(sql);
@@ -94,10 +97,12 @@ public class OutboxTests
             evt: InstanceEventType.Created
         );
 
-        await GetRepo().Insert(first, GetConnection());
-        await GetRepo().Insert(second, GetConnection());
-        await GetRepo().Insert(third, GetConnection());
-        var dps = await GetRepo().Poll(10);
+        var repo = GetRepo();
+        await using var connection = GetConnection();
+        await repo.Insert(first, connection);
+        await repo.Insert(second, connection);
+        await repo.Insert(third, connection);
+        var dps = await repo.Poll(10);
 
         Assert.Equal(2, dps.Count);
     }
@@ -107,8 +112,10 @@ public class OutboxTests
     {
         var cmdObj = CreateCommand(Guid.NewGuid().ToString());
 
-        await GetRepo().Insert(cmdObj, GetConnection());
-        await GetRepo().Delete(Guid.Parse(cmdObj.InstanceId));
+        var repo = GetRepo();
+        await using var connection = GetConnection();
+        await repo.Insert(cmdObj, connection);
+        await repo.Delete(Guid.Parse(cmdObj.InstanceId));
 
         string sql = $"select count(*) from storage.outbox";
         int count = await PostgresUtil.RunCountQuery(sql);
@@ -122,20 +129,19 @@ public class OutboxTests
         var holder = Guid.NewGuid();
         var holder2 = Guid.NewGuid();
 
+        var repo = GetRepo();
+
         // First acquire
-        var ok1 = await GetRepo()
-            .TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(2));
+        var ok1 = await repo.TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(2));
         Assert.True(ok1);
 
         // Second acquire by different holder before expiry should fail
-        var ok2 = await GetRepo()
-            .TryAcquireLeaseAsync(resource, holder2, DateTime.UtcNow.AddSeconds(2));
+        var ok2 = await repo.TryAcquireLeaseAsync(resource, holder2, DateTime.UtcNow.AddSeconds(2));
         Assert.False(ok2);
 
         // Wait until expired
         await Task.Delay(2100);
-        var ok3 = await GetRepo()
-            .TryAcquireLeaseAsync(resource, holder2, DateTime.UtcNow.AddSeconds(2));
+        var ok3 = await repo.TryAcquireLeaseAsync(resource, holder2, DateTime.UtcNow.AddSeconds(2));
         Assert.True(ok3);
     }
 
@@ -145,17 +151,20 @@ public class OutboxTests
         var resource = "r2";
         var holder = Guid.NewGuid();
 
-        var ok1 = await GetRepo()
-            .TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(1));
+        var repo = GetRepo();
+
+        var ok1 = await repo.TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(1));
         Assert.True(ok1);
 
-        var renewed = await GetRepo()
-            .RenewLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(3));
+        var renewed = await repo.RenewLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(3));
         Assert.True(renewed);
 
         // Should still block other holder
-        var other = await GetRepo()
-            .TryAcquireLeaseAsync(resource, Guid.NewGuid(), DateTime.UtcNow.AddSeconds(1));
+        var other = await repo.TryAcquireLeaseAsync(
+            resource,
+            Guid.NewGuid(),
+            DateTime.UtcNow.AddSeconds(1)
+        );
         Assert.False(other);
     }
 
@@ -165,16 +174,21 @@ public class OutboxTests
         var resource = "r3";
         var holder = Guid.NewGuid();
 
+        var repo = GetRepo();
+
         Assert.True(
-            await GetRepo().TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(5))
+            await repo.TryAcquireLeaseAsync(resource, holder, DateTime.UtcNow.AddSeconds(5))
         );
 
-        var released = await GetRepo().ReleaseLeaseAsync(resource, holder);
+        var released = await repo.ReleaseLeaseAsync(resource, holder);
         Assert.True(released);
 
         // Now acquisition by someone else should succeed immediately
-        var ok = await GetRepo()
-            .TryAcquireLeaseAsync(resource, Guid.NewGuid(), DateTime.UtcNow.AddSeconds(2));
+        var ok = await repo.TryAcquireLeaseAsync(
+            resource,
+            Guid.NewGuid(),
+            DateTime.UtcNow.AddSeconds(2)
+        );
         Assert.True(ok);
     }
 

--- a/test/UnitTest/Utils/ServiceUtil.cs
+++ b/test/UnitTest/Utils/ServiceUtil.cs
@@ -13,15 +13,22 @@ namespace Altinn.Platform.Storage.UnitTest.Utils;
 
 public static class ServiceUtil
 {
-    private static readonly object _lock = new();
-    private static ServiceProvider _serviceProvider;
+    private static readonly Lazy<ServiceProvider> _serviceProvider = new(BuildServiceProvider);
 
     public static List<object> GetServices(
         List<Type> interfaceTypes,
         Dictionary<string, string> envVariables = null
     )
     {
-        ServiceProvider serviceProvider = GetServiceProvider(envVariables);
+        if (envVariables != null)
+        {
+            foreach (var item in envVariables)
+            {
+                Environment.SetEnvironmentVariable(item.Key, item.Value);
+            }
+        }
+
+        ServiceProvider serviceProvider = _serviceProvider.Value;
 
         List<object> outputServices = new();
         foreach (Type interfaceType in interfaceTypes)
@@ -39,7 +46,7 @@ public static class ServiceUtil
     /// </summary>
     public static NpgsqlDataSource GetSharedDataSource()
     {
-        return GetServiceProvider(null).GetRequiredService<NpgsqlDataSource>();
+        return _serviceProvider.Value.GetRequiredService<NpgsqlDataSource>();
     }
 
     public static string GetAppsettingsPath()
@@ -47,47 +54,23 @@ public static class ServiceUtil
         return "appsettings.unittest.json";
     }
 
-    private static ServiceProvider GetServiceProvider(Dictionary<string, string> envVariables)
+    private static ServiceProvider BuildServiceProvider()
     {
-        if (_serviceProvider != null)
-        {
-            return _serviceProvider;
-        }
+        var config = new ConfigurationBuilder()
+            .AddJsonFile(GetAppsettingsPath())
+            .AddEnvironmentVariables()
+            .Build();
 
-        lock (_lock)
-        {
-            if (_serviceProvider != null)
-            {
-                return _serviceProvider;
-            }
+        WebApplication.CreateBuilder().Build().SetUpPostgreSql(true, config);
 
-            if (envVariables != null)
-            {
-                foreach (var item in envVariables)
-                {
-                    Environment.SetEnvironmentVariable(item.Key, item.Value);
-                }
-            }
+        IServiceCollection services = new ServiceCollection();
 
-            var builder = new ConfigurationBuilder()
-                .AddJsonFile(GetAppsettingsPath())
-                .AddEnvironmentVariables();
+        services.AddLogging();
+        services.AddPostgresRepositories(config);
+        services.AddMemoryCache();
 
-            var config = builder.Build();
+        services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
 
-            WebApplication.CreateBuilder().Build().SetUpPostgreSql(true, config);
-
-            IServiceCollection services = new ServiceCollection();
-
-            services.AddLogging();
-            services.AddPostgresRepositories(config);
-            services.AddMemoryCache();
-
-            services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
-
-            _serviceProvider = services.BuildServiceProvider();
-        }
-
-        return _serviceProvider;
+        return services.BuildServiceProvider();
     }
 }

--- a/test/UnitTest/Utils/ServiceUtil.cs
+++ b/test/UnitTest/Utils/ServiceUtil.cs
@@ -15,19 +15,8 @@ public static class ServiceUtil
 {
     private static readonly Lazy<ServiceProvider> _serviceProvider = new(BuildServiceProvider);
 
-    public static List<object> GetServices(
-        List<Type> interfaceTypes,
-        Dictionary<string, string> envVariables = null
-    )
+    public static List<object> GetServices(List<Type> interfaceTypes)
     {
-        if (envVariables != null)
-        {
-            foreach (var item in envVariables)
-            {
-                Environment.SetEnvironmentVariable(item.Key, item.Value);
-            }
-        }
-
         ServiceProvider serviceProvider = _serviceProvider.Value;
 
         List<object> outputServices = new();

--- a/test/UnitTest/Utils/ServiceUtil.cs
+++ b/test/UnitTest/Utils/ServiceUtil.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -7,43 +7,23 @@ using Altinn.Platform.Storage.UnitTest.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 
 namespace Altinn.Platform.Storage.UnitTest.Utils;
 
 public static class ServiceUtil
 {
+    private static readonly object _lock = new();
+    private static ServiceProvider _serviceProvider;
+
     public static List<object> GetServices(
         List<Type> interfaceTypes,
         Dictionary<string, string> envVariables = null
     )
     {
-        if (envVariables != null)
-        {
-            foreach (var item in envVariables)
-            {
-                Environment.SetEnvironmentVariable(item.Key, item.Value);
-            }
-        }
+        ServiceProvider serviceProvider = GetServiceProvider(envVariables);
 
-        var builder = new ConfigurationBuilder()
-            .AddJsonFile(GetAppsettingsPath())
-            .AddEnvironmentVariables();
-
-        var config = builder.Build();
-
-        WebApplication.CreateBuilder().Build().SetUpPostgreSql(true, config);
-
-        IServiceCollection services = new ServiceCollection();
-
-        services.AddLogging();
-        services.AddPostgresRepositories(config);
-        services.AddMemoryCache();
-
-        services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
-
-        var serviceProvider = services.BuildServiceProvider();
         List<object> outputServices = new();
-
         foreach (Type interfaceType in interfaceTypes)
         {
             var outputServiceObject = serviceProvider.GetServices(interfaceType)!;
@@ -53,8 +33,61 @@ public static class ServiceUtil
         return outputServices;
     }
 
+    /// <summary>
+    /// The single <see cref="NpgsqlDataSource"/> shared by all tests. Register this instead of
+    /// creating a new one so the whole run shares one connection pool.
+    /// </summary>
+    public static NpgsqlDataSource GetSharedDataSource()
+    {
+        return GetServiceProvider(null).GetRequiredService<NpgsqlDataSource>();
+    }
+
     public static string GetAppsettingsPath()
     {
         return "appsettings.unittest.json";
+    }
+
+    private static ServiceProvider GetServiceProvider(Dictionary<string, string> envVariables)
+    {
+        if (_serviceProvider != null)
+        {
+            return _serviceProvider;
+        }
+
+        lock (_lock)
+        {
+            if (_serviceProvider != null)
+            {
+                return _serviceProvider;
+            }
+
+            if (envVariables != null)
+            {
+                foreach (var item in envVariables)
+                {
+                    Environment.SetEnvironmentVariable(item.Key, item.Value);
+                }
+            }
+
+            var builder = new ConfigurationBuilder()
+                .AddJsonFile(GetAppsettingsPath())
+                .AddEnvironmentVariables();
+
+            var config = builder.Build();
+
+            WebApplication.CreateBuilder().Build().SetUpPostgreSql(true, config);
+
+            IServiceCollection services = new ServiceCollection();
+
+            services.AddLogging();
+            services.AddPostgresRepositories(config);
+            services.AddMemoryCache();
+
+            services.Configure<GeneralSettings>(config.GetSection("GeneralSettings"));
+
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        return _serviceProvider;
     }
 }


### PR DESCRIPTION
## Description
Update `ServiceUtil.cs`  and `ServiceCollectionExtensions.cs` to use common `NpgsqlDataSource`.
When running the tests it was causing errors due to opening too many connection pools at the same time.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL repository DI registration by requiring a single, preconfigured shared database data source (dynamic JSON enabled) for more consistent setup.
* **Tests**
  * Updated outbox repository unit tests to reuse one repository instance and a single opened database connection per test.
  * Improved unit-test reliability by reusing a cached shared DI service provider and a shared database data source.
* **Refactor**
  * Simplified unit-test service provisioning by removing per-call environment/config setup and updating the test helper API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->