### PR TITLE
feat: DataController.cs new endpoint - `/finalize`

### DIFF
--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -734,7 +734,7 @@ public class DataController : ControllerBase
         if (instanceOwnerPartyId == 0 || Request.Body == null)
         {
             return BadRequest(
-                "Missing parameter values: instanceId, datafile or attach1ed file content cannot be empty"
+                "Missing parameter values: instanceId, datafile or attached file content cannot be empty"
             );
         }
 

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -709,6 +709,177 @@ public class DataController : ControllerBase
     }
 
     /// <summary>
+    /// Overwrites an existing data element's content and locks it in a single call, closing the race
+    /// where a clean write and the lock happen as separate requests.
+    /// </summary>
+    [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
+    [HttpPut("data/{dataGuid:guid}/finalize")]
+    [DisableFormValueModelBinding]
+    [RequestSizeLimit(RequestSizeLimit)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    [Produces("application/json")]
+    public async Task<ActionResult<DataElement>> FinalizeData(
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        Guid dataGuid,
+        CancellationToken cancellationToken,
+        [FromQuery(Name = "refs")] List<Guid> refs = null,
+        [FromQuery(Name = "generatedFromTask")] string generatedFromTask = null
+    )
+    {
+        if (instanceOwnerPartyId == 0 || Request.Body == null)
+        {
+            return BadRequest(
+                "Missing parameter values: instanceId, datafile or attach1ed file content cannot be empty"
+            );
+        }
+
+        (Instance instance, _, ActionResult instanceError) = await GetInstanceAsync(
+            instanceGuid,
+            instanceOwnerPartyId,
+            false,
+            cancellationToken
+        );
+        if (instance == null)
+        {
+            return instanceError;
+        }
+
+        (Application application, ActionResult applicationError) = await GetApplicationAsync(
+            instance.AppId,
+            instance.Org,
+            cancellationToken
+        );
+        if (application == null)
+        {
+            return applicationError;
+        }
+
+        (DataElement dataElement, ActionResult dataElementError) = await GetDataElementAsync(
+            instanceGuid,
+            dataGuid,
+            cancellationToken
+        );
+        if (dataElement == null)
+        {
+            return dataElementError;
+        }
+
+        (DataType dataTypeDefinition, ActionResult dataTypeError) = await GetDataTypeAsync(
+            instance,
+            dataElement.DataType,
+            application,
+            cancellationToken
+        );
+        if (dataTypeDefinition == null)
+        {
+            return dataTypeError;
+        }
+
+        if (await dataTypeDefinition.CanWrite(_authorizationService, instance) is not true)
+        {
+            return Forbid();
+        }
+
+        if (dataElement.Locked)
+        {
+            return Conflict($"Data element {dataGuid} is locked and cannot be updated");
+        }
+
+        string blobStoragePathName = DataElementHelper.DataFileName(
+            instance.AppId,
+            instanceGuid.ToString(),
+            dataGuid.ToString()
+        );
+
+        if (!string.Equals(dataElement.BlobStoragePath, blobStoragePathName))
+        {
+            return StatusCode(500, "Storage url does not match with instance metadata");
+        }
+
+        var streamAndDataElement = await ReadRequestAndCreateDataElementAsync(
+            Request,
+            dataElement.DataType,
+            refs,
+            generatedFromTask,
+            instance
+        );
+        Stream theStream = streamAndDataElement.Stream;
+        DataElement updatedData = streamAndDataElement.DataElement;
+
+        if (theStream == null)
+        {
+            return BadRequest("No data found in request body");
+        }
+
+        DateTime changedTime = DateTime.UtcNow;
+
+        (long blobSize, DateTimeOffset blobTimestamp) = await _blobRepository.WriteBlob(
+            instance.Org,
+            theStream,
+            blobStoragePathName,
+            application.StorageAccountNumber
+        );
+
+        if (blobSize <= 0)
+        {
+            return UnprocessableEntity("Could not process attached file");
+        }
+
+        FileScanResult scanResult = dataTypeDefinition.EnableFileScan
+            ? FileScanResult.Pending
+            : FileScanResult.NotApplicable;
+
+        var updatedProperties = new Dictionary<string, object>()
+        {
+            { "/contentType", updatedData.ContentType },
+            { "/filename", HttpUtility.UrlDecode(updatedData.Filename) },
+            { "/lastChangedBy", User.GetUserOrOrgNo() },
+            { "/lastChanged", changedTime },
+            { "/refs", updatedData.Refs },
+            { "/references", updatedData.References },
+            { "/size", blobSize },
+            { "/fileScanResult", scanResult },
+            { "/locked", true },
+        };
+
+        if (User.GetOrg() == instance.Org)
+        {
+            updatedProperties.Add("/isRead", false);
+        }
+
+        DataElement updatedElement = await _dataRepository.Update(
+            instanceGuid,
+            dataGuid,
+            updatedProperties,
+            cancellationToken
+        );
+
+        updatedElement.SetPlatformSelfLinks(_storageBaseAndHost, instanceOwnerPartyId);
+
+        await _dataService.StartFileScan(
+            instance,
+            dataTypeDefinition,
+            dataElement,
+            blobTimestamp,
+            application.StorageAccountNumber,
+            CancellationToken.None
+        );
+
+        await _instanceEventService.DispatchEvent(
+            InstanceEventType.Saved,
+            instance,
+            updatedElement
+        );
+
+        return Ok(updatedElement);
+    }
+
+    /// <summary>
     /// Replaces the existing metadata for a data element with the new data element.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>

--- a/test/UnitTest/Telemetry/AspNetCoreMetricsEnricherTests.ActionsSnapshot.verified.txt
+++ b/test/UnitTest/Telemetry/AspNetCoreMetricsEnricherTests.ActionsSnapshot.verified.txt
@@ -2,6 +2,7 @@
   ActionsToValidate: [
     Altinn.Platform.Storage.Controllers.DataController.CreateAndUploadData (Altinn.Platform.Storage),
     Altinn.Platform.Storage.Controllers.DataController.Delete (Altinn.Platform.Storage),
+    Altinn.Platform.Storage.Controllers.DataController.FinalizeData (Altinn.Platform.Storage),
     Altinn.Platform.Storage.Controllers.DataController.Get (Altinn.Platform.Storage),
     Altinn.Platform.Storage.Controllers.DataController.GetMany (Altinn.Platform.Storage),
     Altinn.Platform.Storage.Controllers.DataController.OverwriteData (Altinn.Platform.Storage),
@@ -30,6 +31,11 @@
       altinn:serviceowner/instances.write
     ],
     Altinn.Platform.Storage.Controllers.DataController.Delete (Altinn.Platform.Storage): [
+      altinn:instances.write,
+      altinn:portal/enduser,
+      altinn:serviceowner/instances.write
+    ],
+    Altinn.Platform.Storage.Controllers.DataController.FinalizeData (Altinn.Platform.Storage): [
       altinn:instances.write,
       altinn:portal/enduser,
       altinn:serviceowner/instances.write

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -131,6 +131,96 @@ public class DataControllerUnitTests
     }
 
     [Fact]
+    public async Task FinalizeData_LocksElementAndVerifyDataRepositoryUpdateInput()
+    {
+        // Arrange
+        List<string> expectedPropertiesForPatch =
+        [
+            "/contentType",
+            "/filename",
+            "/lastChangedBy",
+            "/lastChanged",
+            "/refs",
+            "/size",
+            "/fileScanResult",
+            "/references",
+            "/locked",
+        ];
+
+        (DataController testController, Mock<IDataRepository> dataRepositoryMock) =
+            GetTestController(expectedPropertiesForPatch, true);
+
+        // Act
+        var result = await testController.FinalizeData(
+            _instanceOwnerPartyId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.True(result.Result is OkObjectResult { StatusCode: StatusCodes.Status200OK });
+        dataRepositoryMock.Verify(
+            d =>
+                d.Update(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Guid>(),
+                    It.Is<Dictionary<string, object>>(p =>
+                        VerifyPropertyListInput(
+                            expectedPropertiesForPatch.Count,
+                            expectedPropertiesForPatch,
+                            p
+                        ) && (bool)p["/locked"]
+                    ),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task FinalizeData_LockedElement_ReturnsConflict()
+    {
+        // Arrange
+        (DataController testController, Mock<IDataRepository> dataRepositoryMock) =
+            GetTestController([], true);
+        dataRepositoryMock
+            .Setup(d => d.Read(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                (Guid instanceGuid, Guid dataElementId, CancellationToken cancellationToken) =>
+                    new DataElement
+                    {
+                        Id = dataElementId.ToString(),
+                        InstanceGuid = instanceGuid.ToString(),
+                        DataType = _dataType,
+                        Locked = true,
+                        BlobStoragePath = $"ttd/apps-test/{instanceGuid}/data/{dataElementId}",
+                    }
+            );
+
+        // Act
+        var result = await testController.FinalizeData(
+            _instanceOwnerPartyId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.IsType<ConflictObjectResult>(result.Result);
+        dataRepositoryMock.Verify(
+            d =>
+                d.Update(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<Dictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
     public async Task Update_VerifyDataRepositoryUpdateInput()
     {
         // Arrange


### PR DESCRIPTION
## Description
Add new endpoint to save and lock data element in 1 request.
Currently a copy of OverwriteData endpoint + locking. Followup PR will move common functionality into service layer.

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/17757

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
