### PR TITLE
test: improve test performance

### DIFF
--- a/src/Storage/Services/OutboxService.cs
+++ b/src/Storage/Services/OutboxService.cs
@@ -52,56 +52,73 @@ public class OutboxService(
             using var scope = serviceProvider.CreateScope();
             var outbox = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
             DateTime leaseExpiry = DateTime.UtcNow.AddSeconds(_wolverineSettings.LeaseSecs);
-            if (!await outbox.TryAcquireLeaseAsync(_outboxResource, _podId, leaseExpiry))
+            if (await outbox.TryAcquireLeaseAsync(_outboxResource, _podId, leaseExpiry))
+            {
+                var messageBus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+                await PollWhileHoldingLease(messageBus, outbox, leaseExpiry, stoppingToken);
+            }
+            else
             {
                 await Task.Delay(
                     TimeSpan.FromSeconds(_wolverineSettings.TryGettingPollMasterIntervalSecs),
                     stoppingToken
                 );
             }
-            else
+        }
+    }
+
+    private async Task PollWhileHoldingLease(
+        IMessageBus messageBus,
+        IOutboxRepository outbox,
+        DateTime leaseExpiry,
+        CancellationToken stoppingToken
+    )
+    {
+        _logger.LogInformation("OutboxService with id {PodId} got lease", _podId);
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation("OutboxService with id {PodId} got lease", _podId);
-                var messageBus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
-                while (!stoppingToken.IsCancellationRequested)
+                List<SyncInstanceToDialogportenCommand> dps = [];
+                try
                 {
-                    List<SyncInstanceToDialogportenCommand> dps = [];
-                    try
-                    {
-                        dps = await outbox.Poll(_wolverineSettings.PollMaxSize);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Outbox polling");
-                        await Task.Delay(
-                            TimeSpan.FromMilliseconds(_wolverineSettings.PollErrorDelayMs),
-                            stoppingToken
-                        );
-                    }
+                    dps = await outbox.Poll(_wolverineSettings.PollMaxSize);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Outbox polling");
+                    await Task.Delay(
+                        TimeSpan.FromMilliseconds(_wolverineSettings.PollErrorDelayMs),
+                        stoppingToken
+                    );
+                }
 
-                    await PublishAndDeletePolledMessages(messageBus, outbox, dps, stoppingToken);
+                await PublishAndDeletePolledMessages(messageBus, outbox, dps, stoppingToken);
 
-                    if (
-                        dps.Count < _wolverineSettings.PollMaxSize
-                        && !stoppingToken.IsCancellationRequested
-                    )
-                    {
-                        await Task.Delay(_wolverineSettings.PollIdleTimeMs, stoppingToken);
-                    }
+                if (
+                    dps.Count < _wolverineSettings.PollMaxSize
+                    && !stoppingToken.IsCancellationRequested
+                )
+                {
+                    await Task.Delay(_wolverineSettings.PollIdleTimeMs, stoppingToken);
+                }
 
-                    if (
-                        DateTime.UtcNow
-                        > leaseExpiry.AddSeconds(-_wolverineSettings.LeaseSecs * 0.2)
-                    )
+                if (DateTime.UtcNow > leaseExpiry.AddSeconds(-_wolverineSettings.LeaseSecs * 0.2))
+                {
+                    leaseExpiry = DateTime.UtcNow.AddSeconds(_wolverineSettings.LeaseSecs);
+                    if (!await outbox.RenewLeaseAsync(_outboxResource, _podId, leaseExpiry))
                     {
-                        leaseExpiry = DateTime.UtcNow.AddSeconds(_wolverineSettings.LeaseSecs);
-                        if (!await outbox.RenewLeaseAsync(_outboxResource, _podId, leaseExpiry))
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
             }
+        }
+        finally
+        {
+            // Holder scoped: a no-op if the lease was already lost, and releasing one we still
+            // hold saves the next pod waiting for it to expire.
+            await outbox.ReleaseLeaseAsync(_outboxResource, _podId);
+            _logger.LogInformation("OutboxService with id {PodId} released lease", _podId);
         }
     }
 
@@ -152,29 +169,6 @@ public class OutboxService(
                     );
                 }
             }
-        }
-    }
-
-    /// <summary>
-    /// Stops the background service.
-    /// </summary>
-    /// <param name="cancellationToken">Token to signal cancellation.</param>
-    /// <remarks>
-    /// Release the lease
-    /// </remarks>
-    public override async Task StopAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Let BackgroundService cancel ExecuteAsync and wait for the polling loop to stop before releasing the lease.
-            await base.StopAsync(cancellationToken);
-        }
-        finally
-        {
-            using var scope = serviceProvider.CreateScope();
-            var outbox = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
-            await outbox.ReleaseLeaseAsync(_outboxResource, _podId);
-            _logger.LogInformation("OutboxService with id {PodId} is shutting down", _podId);
         }
     }
 }

--- a/test/UnitTest/TestingServices/OutboxServiceTests.cs
+++ b/test/UnitTest/TestingServices/OutboxServiceTests.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Configuration;
+using Altinn.Platform.Storage.Messages;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Wolverine;
 using Xunit;
 
 namespace Altinn.Platform.Storage.UnitTest.TestingServices;
@@ -15,7 +18,7 @@ namespace Altinn.Platform.Storage.UnitTest.TestingServices;
 public class OutboxServiceTests
 {
     [Fact]
-    public async Task StopAsync_CancelsBackgroundExecutionAndReleasesLease()
+    public async Task StopAsync_LeaseNeverAcquired_DoesNotReleaseLease()
     {
         var leasePollStarted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously
@@ -25,11 +28,8 @@ public class OutboxServiceTests
             .Setup(repository =>
                 repository.TryAcquireLeaseAsync("outbox", It.IsAny<Guid>(), It.IsAny<DateTime>())
             )
-            .Callback(() => leasePollStarted.SetResult())
+            .Callback(() => leasePollStarted.TrySetResult())
             .ReturnsAsync(false);
-        outbox
-            .Setup(repository => repository.ReleaseLeaseAsync("outbox", It.IsAny<Guid>()))
-            .ReturnsAsync(true);
 
         await using ServiceProvider services = new ServiceCollection()
             .AddSingleton(outbox.Object)
@@ -50,6 +50,61 @@ public class OutboxServiceTests
 
         await service.StartAsync(CancellationToken.None);
         await leasePollStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await service.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(service.ExecuteTask);
+        Assert.True(service.ExecuteTask.IsCompleted);
+        outbox.Verify(
+            repository => repository.ReleaseLeaseAsync("outbox", It.IsAny<Guid>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task StopAsync_LeaseAcquired_CancelsBackgroundExecutionAndReleasesLease()
+    {
+        var pollStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var outbox = new Mock<IOutboxRepository>(MockBehavior.Strict);
+        outbox
+            .Setup(repository =>
+                repository.TryAcquireLeaseAsync("outbox", It.IsAny<Guid>(), It.IsAny<DateTime>())
+            )
+            .ReturnsAsync(true);
+        outbox
+            .Setup(repository => repository.Poll(It.IsAny<int>()))
+            .Callback(() => pollStarted.TrySetResult())
+            .ReturnsAsync(new List<SyncInstanceToDialogportenCommand>());
+        outbox
+            .Setup(repository => repository.ReleaseLeaseAsync("outbox", It.IsAny<Guid>()))
+            .ReturnsAsync(true);
+
+        await using ServiceProvider services = new ServiceCollection()
+            .AddSingleton(outbox.Object)
+            .AddSingleton(new Mock<IMessageBus>().Object)
+            .BuildServiceProvider();
+
+        var service = new OutboxService(
+            NullLogger<OutboxService>.Instance,
+            services,
+            Options.Create(
+                new WolverineSettings
+                {
+                    EnableSending = true,
+                    TryGettingPollMasterIntervalSecs = 60,
+                    LeaseSecs = 60,
+
+                    // Long enough that the polling loop parks in the idle delay, so the stop below
+                    // has to cancel it.
+                    PollIdleTimeMs = 60_000,
+                }
+            )
+        );
+
+        await service.StartAsync(CancellationToken.None);
+        await pollStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         await service.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(2));
 

--- a/test/UnitTest/appsettings.unittest.json
+++ b/test/UnitTest/appsettings.unittest.json
@@ -44,14 +44,14 @@
     "MigrationScriptPath": "../../../../src/Storage/Migration",
     "EnableDebug": false,
     "LogParameters": false,
-    "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_storage_admin;Password={0};Database=storagedb",
-    "ConnectionString": "Host=localhost;Port=5432;Username=platform_storage;Password={0};Database=storagedb",
+    "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_storage_admin;Password={0};Database=storagedb;GSS Encryption Mode=Disable",
+    "ConnectionString": "Host=localhost;Port=5432;Username=platform_storage;Password={0};Database=storagedb;GSS Encryption Mode=Disable",
     "StorageDbAdminPwd": "Password",
     "StorageDbPwd": "Password"
   },
   "WolverineSettings": {
     "ServiceBusConnectionString": "",
-    "PostgresConnectionString": "Host=localhost;Port=5432;Username=platform_storage;Password=Password;Database=storagedb",
+    "PostgresConnectionString": "Host=localhost;Port=5432;Username=platform_storage;Password=Password;Database=storagedb;GSS Encryption Mode=Disable",
     "EnableCustomOutbox": false,
     "EnableWolverineOutbox": true
   }


### PR DESCRIPTION
## Description
In major version 10 of `Npgsql` the package changed default encryption, updated connection strings in `appsettings.unittest.json` to disable GSS encryption.

Updated `OutboxService.cs` to allow tests to not wait on slow `StopAsync` method, moved `ReleaseLeaseAsync` out to a try catch block under the `ExecuteAsync` method.

End result, local test run time going from 7 minutes -> 40-80 seconds.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outbox processing shutdown behavior so active leases are released reliably when polling stops.
  - Prevented unnecessary lease-release attempts when a lease was never acquired.
  - Improved handling of idle polling during service shutdown, helping background processing stop cleanly.

- **Refactor**
  - Centralized outbox lease management to provide more consistent lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->