### PR TITLE
fix: downgrade Azure.Monitor.OpenTelemetry.Exporter to 1.8.2

### DIFF
--- a/src/Storage/Altinn.Platform.Storage.csproj
+++ b/src/Storage/Altinn.Platform.Storage.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Npgsql.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />


### PR DESCRIPTION
## Description
Revert upgrade of `Azure.Monitor.OpenTelemetry.Exporter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Azure Monitor OpenTelemetry Exporter package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->