### PR TITLE
fix: make DataType.EnablePdfCreation nullable and deprecate it

### DIFF
--- a/src/Storage.Interface/Models/DataType.cs
+++ b/src/Storage.Interface/Models/DataType.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
+using TextJson = System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Storage.Interface.Models;
 
@@ -116,8 +117,20 @@ public class DataType
     /// <summary>
     /// Gets or sets a value indicating whether the element should trigger PDF generation
     /// </summary>
+    /// <remarks>
+    /// Deprecated. Configure a PDF service task in the process instead, which app backends support
+    /// from v8.9 onwards; v9 app backends ignore this property entirely.
+    /// <para>
+    /// This property is nullable, and an absent value no longer deserializes to <c>true</c>. Callers
+    /// that need the historical v8 default must read it as <c>EnablePdfCreation ?? true</c>.
+    /// </para>
+    /// </remarks>
     [JsonProperty(PropertyName = "enablePdfCreation")]
-    public bool EnablePdfCreation { get; set; } = true;
+    [TextJson.JsonIgnore(Condition = TextJson.JsonIgnoreCondition.WhenWritingNull)]
+    [Obsolete(
+        "Deprecated: configure a PDF service task in the process instead, supported by app backends from v8.9 onwards. Ignored entirely by v9 app backends. Now nullable for backwards compatibility - absent no longer means true, so read it as (EnablePdfCreation ?? true)."
+    )]
+    public bool? EnablePdfCreation { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether file uploaded to this data type should be scanned for malware. Default value is <c>false</c>.


### PR DESCRIPTION
## Description

Makes `DataType.EnablePdfCreation` nullable and marks it `[Obsolete]`.

The property was a non-nullable `bool` with a `= true` initializer, so it could never round-trip as
"absent": an absent value deserialized to `true` and was then written straight back out. Any consumer
that rewrites application metadata therefore re-added the flag to **every** dataType, including ones
where it had been deliberately removed. For v9 apps that breaks the build outright, because the app
backend analyzer rejects `enablePdfCreation: true` (`ALTINNAPP0600`) — and the app stays broken,
because deleting the lines by hand only survives until the next write.

`bool?` lets absence survive the round-trip. Two deliberate choices in how it is annotated:

- **The System.Text.Json ignore condition is needed**, so that a null is not serialized as an explicit
  `null` by consumers that do not set a global `DefaultIgnoreCondition`. Storage's own Npgsql path is
  one such consumer, and `_createSql` wraps the document in `jsonb_strip_nulls` while `_updateSql`
  does not — so without it, updated rows would carry `"EnablePdfCreation": null`.
- **No per-property Newtonsoft `NullValueHandling` is added**, because it would be redundant: the
  class already carries `[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]`, and no other
  property on `DataType` sets it per-member.

No System.Text.Json *property name* is introduced either, deliberately. `DataType` is
Newtonsoft-annotated only, and `PgApplicationRepository` serializes `Application` through Npgsql with
default STJ options, so the keys stored in `storage.applications` are PascalCase — as the SQL itself
shows, re-reading `application->>$4` with `$4 = nameof(item.Created)` on every update. Adding
`[JsonPropertyName]` would rename that member's key in new writes and orphan it in existing rows.

### Piggybacking on this branch

Targeted at `feat/interface-aggregate-mutation` rather than `main` to avoid a second version bump for
one property. Worth flagging to whoever cuts the release: **#1068 on its own is additive, and this
commit makes the combined release source-breaking.** Since versioning is MinVer-driven off the
`Storage.Interface-` tag, that choice sits with the tagger rather than with this PR — but a major is
the honest call, and it has the useful side effect that Renovate asks a human before bumping.

### Downstream consumers that will need a follow-up

Two read sites exist across the org, and both become **compile errors** on bump rather than silent
behaviour changes:

- `Altinn/app-lib-dotnet` (v8) — `PdfServiceTaskLegacy.cs:44`, the only v8 runtime read
- `Altinn/altinn-dialogporten-adapter` — `StorageDialogportenDataMerger.cs:452`, in `AllPdfsGenerated`

Both want `EnablePdfCreation ?? true` to preserve the historical v8 default. Two notes for whoever
does that work:

- `.GetValueOrDefault()` and `== true` both compile and both silently **disable** PDF generation for
  apps that never set the flag. `?? true` is the only correct reading.
- `?? true` cannot be prepared in advance — it does not compile against the current non-nullable
  property (`CS0019`) — so in each repo the package bump and the patch have to land in the same
  commit. There is no pre-patching phase.

Both sites are legitimate v8 compatibility shims, so suppressing `CS0618` there with a justification
is the expected outcome. Nothing in this repository reads the property, so `[Obsolete]` produces no
warnings here despite `TreatWarningsAsErrors`.

## Related Issue(s)

- Altinn/altinn-studio#19667 (the Designer-side bug this unblocks, with the full cross-repo plan)

## Verification

- [x] **Your** code builds clean without any errors or warnings — full solution with
      `--no-incremental`: 0 warnings, 0 errors
- [x] Manual testing done (required) — verified no C# in this repo reads the property, so the
      `[Obsolete]` is inert here; confirmed the stored JSONB keys are PascalCase before ruling out an
      STJ property name
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) — no new test:
      the existing `Storage.Interface.Tests` fixtures carry `enablePdfCreation` with explicit values on
      both sides of every before/after pair, so round-trip coverage is unchanged and no assertion in
      this repo touches the property
- [x] All tests run green — `Altinn.Platform.Storage.Interface.Tests` 8/8 pass; `csharpier check` clean

## Documentation

- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

`enablePdfCreation` is currently absent from the documented `DataType` property table at
`docs.altinn.studio/nb/api/models/app-metadata/` — it appears only inside a JSON example, and its
default was never documented. Out of scope here, noted in Altinn/altinn-studio#19667.
