### PR TITLE
feat: serve data element content from versioned blob paths

### DIFF
--- a/src/Storage/Controllers/ContentOnDemandController.cs
+++ b/src/Storage/Controllers/ContentOnDemandController.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Clients;
 using Altinn.Platform.Storage.Configuration;
+using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
 using Altinn.Platform.Storage.Services;
@@ -119,6 +120,7 @@ public class ContentOnDemandController : Controller
             cancellationToken
         );
         DataElement signatureElement = instance.Data.First(d => d.DataType == "signature-data");
+        EnsureExpectedBlobStoragePath(signatureElement, instance.AppId, instanceGuid);
 
         List<SignatureView> view = await JsonSerializer.DeserializeAsync<List<SignatureView>>(
             await _blobRepository.ReadBlob(
@@ -165,6 +167,7 @@ public class ContentOnDemandController : Controller
             cancellationToken
         );
         DataElement paymentElement = instance.Data.First(d => d.DataType == "payment-data");
+        EnsureExpectedBlobStoragePath(paymentElement, instance.AppId, instanceGuid);
 
         PaymentView view = await JsonSerializer.DeserializeAsync<PaymentView>(
             await _blobRepository.ReadBlob(
@@ -416,6 +419,7 @@ public class ContentOnDemandController : Controller
         DataElement xmlElement = instance.Data.First(d =>
             d.Metadata?.First(m => m.Key == "formid").Value == htmlFormId && d.Id != htmlElement.Id
         );
+        EnsureExpectedBlobStoragePath(xmlElement, instance.AppId, instanceGuid);
         string visiblePagesString = xmlElement
             .Metadata.FirstOrDefault(m => m.Key == "A2VisiblePages")
             ?.Value;
@@ -467,6 +471,27 @@ public class ContentOnDemandController : Controller
         );
 
         return (_a2OndemandFormattingService.GetFormdataHtml(views, blob), views);
+    }
+
+    private static void EnsureExpectedBlobStoragePath(
+        DataElement dataElement,
+        string appId,
+        Guid instanceGuid
+    )
+    {
+        if (
+            !DataElementHelper.IsExpectedBlobStoragePath(
+                dataElement.BlobStoragePath,
+                appId,
+                instanceGuid.ToString(),
+                dataElement.Id
+            )
+        )
+        {
+            throw new InvalidOperationException(
+                $"Blob storage path of data element {dataElement.Id} was unexpected for instance {instanceGuid}"
+            );
+        }
     }
 
     private static float GetScale(PrintViewXslBE infoPathViewXslBE)

--- a/src/Storage/Controllers/ContentOnDemandController.cs
+++ b/src/Storage/Controllers/ContentOnDemandController.cs
@@ -123,7 +123,7 @@ public class ContentOnDemandController : Controller
         List<SignatureView> view = await JsonSerializer.DeserializeAsync<List<SignatureView>>(
             await _blobRepository.ReadBlob(
                 $"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}",
-                $"{instance.Org}/{app}/{instanceGuid}/data/{signatureElement.Id}",
+                signatureElement.BlobStoragePath,
                 application.StorageAccountNumber,
                 cancellationToken
             ),
@@ -169,7 +169,7 @@ public class ContentOnDemandController : Controller
         PaymentView view = await JsonSerializer.DeserializeAsync<PaymentView>(
             await _blobRepository.ReadBlob(
                 $"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}",
-                $"{instance.Org}/{app}/{instanceGuid}/data/{paymentElement.Id}",
+                paymentElement.BlobStoragePath,
                 application.StorageAccountNumber,
                 cancellationToken
             ),
@@ -462,7 +462,7 @@ public class ContentOnDemandController : Controller
 
         Stream blob = await _blobRepository.ReadBlob(
             $"{(_generalSettings.A2UseTtdAsServiceOwner ? "ttd" : instance.Org)}",
-            $"{instance.Org}/{app}/{instanceGuid}/data/{xmlElement.Id}",
+            xmlElement.BlobStoragePath,
             application.StorageAccountNumber
         );
 

--- a/src/Storage/Controllers/ContentOnDemandController.cs
+++ b/src/Storage/Controllers/ContentOnDemandController.cs
@@ -120,7 +120,11 @@ public class ContentOnDemandController : Controller
             cancellationToken
         );
         DataElement signatureElement = instance.Data.First(d => d.DataType == "signature-data");
-        EnsureExpectedBlobStoragePath(signatureElement, instance.AppId, instanceGuid);
+        DataElementHelper.EnsureExpectedBlobStoragePath(
+            signatureElement,
+            instanceGuid,
+            instance.AppId
+        );
 
         List<SignatureView> view = await JsonSerializer.DeserializeAsync<List<SignatureView>>(
             await _blobRepository.ReadBlob(
@@ -167,7 +171,11 @@ public class ContentOnDemandController : Controller
             cancellationToken
         );
         DataElement paymentElement = instance.Data.First(d => d.DataType == "payment-data");
-        EnsureExpectedBlobStoragePath(paymentElement, instance.AppId, instanceGuid);
+        DataElementHelper.EnsureExpectedBlobStoragePath(
+            paymentElement,
+            instanceGuid,
+            instance.AppId
+        );
 
         PaymentView view = await JsonSerializer.DeserializeAsync<PaymentView>(
             await _blobRepository.ReadBlob(
@@ -419,7 +427,7 @@ public class ContentOnDemandController : Controller
         DataElement xmlElement = instance.Data.First(d =>
             d.Metadata?.First(m => m.Key == "formid").Value == htmlFormId && d.Id != htmlElement.Id
         );
-        EnsureExpectedBlobStoragePath(xmlElement, instance.AppId, instanceGuid);
+        DataElementHelper.EnsureExpectedBlobStoragePath(xmlElement, instanceGuid, instance.AppId);
         string visiblePagesString = xmlElement
             .Metadata.FirstOrDefault(m => m.Key == "A2VisiblePages")
             ?.Value;
@@ -471,27 +479,6 @@ public class ContentOnDemandController : Controller
         );
 
         return (_a2OndemandFormattingService.GetFormdataHtml(views, blob), views);
-    }
-
-    private static void EnsureExpectedBlobStoragePath(
-        DataElement dataElement,
-        string appId,
-        Guid instanceGuid
-    )
-    {
-        if (
-            !DataElementHelper.IsExpectedBlobStoragePath(
-                dataElement.BlobStoragePath,
-                appId,
-                instanceGuid.ToString(),
-                dataElement.Id
-            )
-        )
-        {
-            throw new InvalidOperationException(
-                $"Blob storage path of data element {dataElement.Id} was unexpected for instance {instanceGuid}"
-            );
-        }
     }
 
     private static float GetScale(PrintViewXslBE infoPathViewXslBE)

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -287,12 +287,6 @@ public class DataController : ControllerBase
             );
         }
 
-        string storageFileName = DataElementHelper.DataFileName(
-            instance.AppId,
-            instanceGuid.ToString(),
-            dataGuid.ToString()
-        );
-
         if (
             (instance.AppId.Contains(@"/a1-") || instance.AppId.Contains(@"/a2-"))
             && _generalSettings.A2UseTtdAsServiceOwner
@@ -301,11 +295,18 @@ public class DataController : ControllerBase
             instance.Org = "ttd";
         }
 
-        if (string.Equals(dataElement.BlobStoragePath, storageFileName))
+        if (
+            DataElementHelper.IsExpectedBlobStoragePath(
+                dataElement.BlobStoragePath,
+                instance.AppId,
+                instanceGuid.ToString(),
+                dataGuid.ToString()
+            )
+        )
         {
             Stream dataStream = await _blobRepository.ReadBlob(
                 instance.Org,
-                storageFileName,
+                dataElement.BlobStoragePath,
                 application.StorageAccountNumber,
                 cancellationToken
             );
@@ -619,13 +620,14 @@ public class DataController : ControllerBase
             return Conflict($"Data element {dataGuid} is locked and cannot be updated");
         }
 
-        string blobStoragePathName = DataElementHelper.DataFileName(
-            instance.AppId,
-            instanceGuid.ToString(),
-            dataGuid.ToString()
-        );
-
-        if (!string.Equals(dataElement.BlobStoragePath, blobStoragePathName))
+        if (
+            !DataElementHelper.IsExpectedBlobStoragePath(
+                dataElement.BlobStoragePath,
+                instance.AppId,
+                instanceGuid.ToString(),
+                dataGuid.ToString()
+            )
+        )
         {
             return StatusCode(500, "Storage url does not match with instance metadata");
         }
@@ -650,7 +652,7 @@ public class DataController : ControllerBase
         (long blobSize, DateTimeOffset blobTimestamp) = await _blobRepository.WriteBlob(
             instance.Org,
             theStream,
-            blobStoragePathName,
+            dataElement.BlobStoragePath,
             application.StorageAccountNumber
         );
 

--- a/src/Storage/Controllers/DataController.cs
+++ b/src/Storage/Controllers/DataController.cs
@@ -295,46 +295,7 @@ public class DataController : ControllerBase
             instance.Org = "ttd";
         }
 
-        if (
-            DataElementHelper.IsExpectedBlobStoragePath(
-                dataElement.BlobStoragePath,
-                instance.AppId,
-                instanceGuid.ToString(),
-                dataGuid.ToString()
-            )
-        )
-        {
-            Stream dataStream = await _blobRepository.ReadBlob(
-                instance.Org,
-                dataElement.BlobStoragePath,
-                application.StorageAccountNumber,
-                cancellationToken
-            );
-
-            if (dataStream == null)
-            {
-                return NotFound($"Unable to read data element from blob storage for {dataGuid}");
-            }
-
-            // Migrated Altinn 2 Websa main forms should be shown inline in the browser
-            if (
-                instance.AppId.Contains(@"/a2-")
-                && dataElement.DataType == "ref-data-as-pdf"
-                && dataElement.ContentType == "text/html"
-            )
-            {
-                var contentDispositionHeader = new ContentDispositionHeaderValue("inline");
-                contentDispositionHeader.SetHttpFileName(dataElement.Filename);
-                Response.Headers.Append(
-                    HeaderNames.ContentDisposition,
-                    contentDispositionHeader.ToString()
-                );
-                return File(dataStream, dataElement.ContentType);
-            }
-
-            return File(dataStream, dataElement.ContentType, dataElement.Filename);
-        }
-        else if (dataElement.BlobStoragePath.StartsWith("ondemand"))
+        if (dataElement.BlobStoragePath.StartsWith("ondemand"))
         {
             var contentDispositionHeader = new ContentDispositionHeaderValue("inline");
             contentDispositionHeader.SetHttpFileName(dataElement.Filename);
@@ -352,7 +313,37 @@ public class DataController : ControllerBase
             );
         }
 
-        return NotFound("Unable to find requested data item");
+        DataElementHelper.EnsureExpectedBlobStoragePath(dataElement, instanceGuid, instance.AppId);
+
+        Stream dataStream = await _blobRepository.ReadBlob(
+            instance.Org,
+            dataElement.BlobStoragePath,
+            application.StorageAccountNumber,
+            cancellationToken
+        );
+
+        if (dataStream == null)
+        {
+            return NotFound($"Unable to read data element from blob storage for {dataGuid}");
+        }
+
+        // Migrated Altinn 2 Websa main forms should be shown inline in the browser
+        if (
+            instance.AppId.Contains(@"/a2-")
+            && dataElement.DataType == "ref-data-as-pdf"
+            && dataElement.ContentType == "text/html"
+        )
+        {
+            var contentDispositionHeader = new ContentDispositionHeaderValue("inline");
+            contentDispositionHeader.SetHttpFileName(dataElement.Filename);
+            Response.Headers.Append(
+                HeaderNames.ContentDisposition,
+                contentDispositionHeader.ToString()
+            );
+            return File(dataStream, dataElement.ContentType);
+        }
+
+        return File(dataStream, dataElement.ContentType, dataElement.Filename);
     }
 
     /// <summary>
@@ -620,17 +611,7 @@ public class DataController : ControllerBase
             return Conflict($"Data element {dataGuid} is locked and cannot be updated");
         }
 
-        if (
-            !DataElementHelper.IsExpectedBlobStoragePath(
-                dataElement.BlobStoragePath,
-                instance.AppId,
-                instanceGuid.ToString(),
-                dataGuid.ToString()
-            )
-        )
-        {
-            return StatusCode(500, "Storage url does not match with instance metadata");
-        }
+        DataElementHelper.EnsureExpectedBlobStoragePath(dataElement, instanceGuid, instance.AppId);
 
         var streamAndDataElement = await ReadRequestAndCreateDataElementAsync(
             Request,

--- a/src/Storage/Helpers/DataElementHelper.cs
+++ b/src/Storage/Helpers/DataElementHelper.cs
@@ -87,6 +87,47 @@ public static class DataElementHelper
     }
 
     /// <summary>
+    /// Determines whether data element content can be read from and overwritten at
+    /// <paramref name="blobStoragePath"/>. Content this build writes lives at
+    /// <see cref="DataFileName"/>. Content written by a build with blob versioning enabled lives at a
+    /// versioned path under the instance, whose final segment identifies the stored blob version
+    /// rather than the data element.
+    /// </summary>
+    public static bool IsExpectedBlobStoragePath(
+        string blobStoragePath,
+        string appId,
+        string instanceGuid,
+        string dataElementId
+    )
+    {
+        if (string.IsNullOrEmpty(blobStoragePath))
+        {
+            return false;
+        }
+
+        if (
+            string.Equals(
+                blobStoragePath,
+                DataFileName(appId, instanceGuid, dataElementId),
+                StringComparison.Ordinal
+            )
+        )
+        {
+            return true;
+        }
+
+        string versionedPathPrefix = $"{appId}/{instanceGuid}/data-elements/";
+        if (!blobStoragePath.StartsWith(versionedPathPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> blobVersionId = blobStoragePath.AsSpan(versionedPathPrefix.Length);
+
+        return blobVersionId.ContainsAnyExcept('.') && !blobVersionId.Contains('/');
+    }
+
+    /// <summary>
     /// Get the stream from the request
     /// </summary>
     /// <param name="request">The request</param>

--- a/src/Storage/Helpers/DataElementHelper.cs
+++ b/src/Storage/Helpers/DataElementHelper.cs
@@ -87,44 +87,27 @@ public static class DataElementHelper
     }
 
     /// <summary>
-    /// Determines whether data element content can be read from and overwritten at
-    /// <paramref name="blobStoragePath"/>. Content this build writes lives at
-    /// <see cref="DataFileName"/>. Content written by a build with blob versioning enabled lives at a
-    /// versioned path under the instance, whose final segment identifies the stored blob version
-    /// rather than the data element.
+    /// Throws an exception if the blob storage path isn't in the excpected format.
     /// </summary>
-    public static bool IsExpectedBlobStoragePath(
-        string blobStoragePath,
-        string appId,
-        string instanceGuid,
-        string dataElementId
+    public static void EnsureExpectedBlobStoragePath(
+        DataElement dataElement,
+        Guid instanceGuid,
+        string appId
     )
     {
-        if (string.IsNullOrEmpty(blobStoragePath))
-        {
-            return false;
-        }
-
         if (
-            string.Equals(
-                blobStoragePath,
-                DataFileName(appId, instanceGuid, dataElementId),
-                StringComparison.Ordinal
+            !IsExpectedBlobStoragePath(
+                dataElement.BlobStoragePath,
+                appId,
+                instanceGuid.ToString(),
+                dataElement.Id
             )
         )
         {
-            return true;
+            throw new InvalidOperationException(
+                $"Blob storage path of data element {dataElement.Id} was unexpected for instance {instanceGuid}."
+            );
         }
-
-        string versionedPathPrefix = $"{appId}/{instanceGuid}/data-elements/";
-        if (!blobStoragePath.StartsWith(versionedPathPrefix, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        ReadOnlySpan<char> blobVersionId = blobStoragePath.AsSpan(versionedPathPrefix.Length);
-
-        return blobVersionId.ContainsAnyExcept('.') && !blobVersionId.Contains('/');
     }
 
     /// <summary>
@@ -188,5 +171,39 @@ public static class DataElementHelper
         }
 
         return (stream, contentType, contentFileName, fileSize);
+    }
+
+    internal static bool IsExpectedBlobStoragePath(
+        string blobStoragePath,
+        string appId,
+        string instanceGuid,
+        string dataElementId
+    )
+    {
+        if (string.IsNullOrEmpty(blobStoragePath))
+        {
+            return false;
+        }
+
+        if (
+            string.Equals(
+                blobStoragePath,
+                DataFileName(appId, instanceGuid, dataElementId),
+                StringComparison.Ordinal
+            )
+        )
+        {
+            return true;
+        }
+
+        string versionedPathPrefix = $"{appId}/{instanceGuid}/data-elements/";
+        if (!blobStoragePath.StartsWith(versionedPathPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> blobVersionId = blobStoragePath.AsSpan(versionedPathPrefix.Length);
+
+        return blobVersionId.ContainsAnyExcept('.') && !blobVersionId.Contains('/');
     }
 }

--- a/test/UnitTest/HelperTests/DataElementHelperTests.cs
+++ b/test/UnitTest/HelperTests/DataElementHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 
 using System;
+using System.Buffers.Text;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
@@ -10,6 +11,55 @@ namespace Altinn.Platform.Storage.UnitTest.HelperTests;
 
 public class DataElementHelperTests
 {
+    [Theory]
+    [InlineData("{appId}/{instanceGuid}/data/{dataElementId}", true)]
+    [InlineData("{appId}/{instanceGuid}/data-elements/{blobVersionId}", true)]
+    [InlineData(null, false)]
+    [InlineData("{appId}/{instanceGuid}/data/{otherDataElementId}", false)]
+    [InlineData("{appId}/{otherInstanceGuid}/data-elements/{blobVersionId}", false)]
+    [InlineData("{otherAppId}/{instanceGuid}/data-elements/{blobVersionId}", false)]
+    [InlineData("{appId}/{instanceGuid}/data-elements/", false)]
+    [InlineData("{appId}/{instanceGuid}/data-elements/nested/{blobVersionId}", false)]
+    [InlineData("{appId}/{instanceGuid}/data-elements/.", false)]
+    [InlineData("{appId}/{instanceGuid}/data-elements/..", false)]
+    [InlineData("ondemand/{appId}/{instanceGuid}/data/{dataElementId}", false)]
+    public void IsExpectedBlobStoragePath_ReturnsWhetherPathBelongsToDataElement(
+        string blobStoragePathTemplate,
+        bool expected
+    )
+    {
+        // Arrange
+        string appId = "ttd/app";
+        string instanceGuid = $"{Guid.NewGuid()}";
+        string dataElementId = $"{Guid.NewGuid()}";
+
+        // The blob versioning build encodes the version id as base64url of a v7 guid in
+        // canonical byte order, which keeps the encoded id sorted by creation time.
+        string blobVersionId = Base64Url.EncodeToString(
+            Guid.CreateVersion7().ToByteArray(bigEndian: true)
+        );
+
+        string blobStoragePath = blobStoragePathTemplate
+            ?.Replace("{otherAppId}", "ttd/other-app")
+            .Replace("{otherInstanceGuid}", $"{Guid.NewGuid()}")
+            .Replace("{otherDataElementId}", $"{Guid.NewGuid()}")
+            .Replace("{appId}", appId)
+            .Replace("{instanceGuid}", instanceGuid)
+            .Replace("{dataElementId}", dataElementId)
+            .Replace("{blobVersionId}", blobVersionId);
+
+        // Act
+        bool actual = DataElementHelper.IsExpectedBlobStoragePath(
+            blobStoragePath,
+            appId,
+            instanceGuid,
+            dataElementId
+        );
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
     [Fact]
     public void CreateDataElement_GeneratedFromTaskProvided_DataElementReferencesPopulated()
     {

--- a/test/UnitTest/TestingControllers/ContentOnDemandControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ContentOnDemandControllerTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -90,6 +91,34 @@ public class ContentOnDemandControllerTests
         Assert.Equal(_html, await response.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public async Task GetFormdataAsHtml_XmlElementAtVersionedBlobStoragePath_ReadsStoredPath()
+    {
+        // Arrange
+        Mock<IBlobRepository> blobRepositoryMock = new();
+        HttpClient client = GetTestClient(blobRepositoryMock);
+        string requestUri = GetRequestUri("formdatahtml");
+        string xmlBlobStoragePath = GetInstance()
+            .Data.First(d => d.DataType == "a2-xml")
+            .BlobStoragePath;
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        blobRepositoryMock.Verify(
+            br =>
+                br.ReadBlob(
+                    _org,
+                    xmlBlobStoragePath,
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
     private static Instance GetInstance()
     {
         return new Instance
@@ -111,6 +140,8 @@ public class ContentOnDemandControllerTests
                 {
                     Id = "3a1b2f4c-7a1e-4b25-9f0f-0d6a0f3a5b21",
                     DataType = "a2-xml",
+                    BlobStoragePath =
+                        $"{_org}/{_app}/{_instanceGuid}/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA",
                     Metadata =
                     [
                         new KeyValueEntry { Key = "formid", Value = "1000" },
@@ -121,7 +152,7 @@ public class ContentOnDemandControllerTests
         };
     }
 
-    private HttpClient GetTestClient()
+    private HttpClient GetTestClient(Mock<IBlobRepository> blobRepositoryMock = null)
     {
         Mock<IInstanceRepository> instanceRepositoryMock = new();
         instanceRepositoryMock
@@ -143,7 +174,7 @@ public class ContentOnDemandControllerTests
             .Setup(ar => ar.GetXsls(_org, _app, 2000, "nb", It.IsAny<int>()))
             .ReturnsAsync(xsls);
 
-        Mock<IBlobRepository> blobRepositoryMock = new();
+        blobRepositoryMock ??= new();
         blobRepositoryMock
             .Setup(br =>
                 br.ReadBlob(

--- a/test/UnitTest/TestingControllers/ContentOnDemandControllerTests.cs
+++ b/test/UnitTest/TestingControllers/ContentOnDemandControllerTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -28,14 +27,14 @@ public class ContentOnDemandControllerTests
 {
     private const string _basePath = "storage/api/v1/ondemand";
     private const string _html = "<html><body>formdata</body></html>";
-
-    private readonly TestApplicationFactory<ContentOnDemandController> _factory;
-
     private const string _org = "ttd";
     private const string _app = "a2-app";
     private const int _instanceOwnerPartyId = 1337;
     private static readonly Guid _instanceGuid = new("1916cd18-3b8e-46f8-aeaf-4bc3397ddd55");
     private static readonly Guid _htmlDataGuid = new("11f7c994-6681-4e3d-a3ba-6b19bbf3e5f6");
+    private static readonly Guid _xmlDataGuid = new("3a1b2f4c-7a1e-4b25-9f0f-0d6a0f3a5b21");
+
+    private readonly TestApplicationFactory<ContentOnDemandController> _factory;
 
     /// <summary>
     /// Constructor.
@@ -95,12 +94,11 @@ public class ContentOnDemandControllerTests
     public async Task GetFormdataAsHtml_XmlElementAtVersionedBlobStoragePath_ReadsStoredPath()
     {
         // Arrange
+        string xmlBlobStoragePath =
+            $"{_org}/{_app}/{_instanceGuid}/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA";
         Mock<IBlobRepository> blobRepositoryMock = new();
-        HttpClient client = GetTestClient(blobRepositoryMock);
+        HttpClient client = GetTestClient(blobRepositoryMock, xmlBlobStoragePath);
         string requestUri = GetRequestUri("formdatahtml");
-        string xmlBlobStoragePath = GetInstance()
-            .Data.First(d => d.DataType == "a2-xml")
-            .BlobStoragePath;
 
         // Act
         HttpResponseMessage response = await client.GetAsync(requestUri);
@@ -119,7 +117,34 @@ public class ContentOnDemandControllerTests
         );
     }
 
-    private static Instance GetInstance()
+    [Fact]
+    public async Task GetFormdataAsHtml_XmlElementBlobOutsideInstance_ReturnsInternalServerError()
+    {
+        // Arrange
+        string otherInstanceBlobStoragePath =
+            $"{_org}/{_app}/{Guid.NewGuid()}/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA";
+        Mock<IBlobRepository> blobRepositoryMock = new();
+        HttpClient client = GetTestClient(blobRepositoryMock, otherInstanceBlobStoragePath);
+        string requestUri = GetRequestUri("formdatahtml");
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync(requestUri);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        blobRepositoryMock.Verify(
+            br =>
+                br.ReadBlob(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    private static Instance GetInstance(string xmlBlobStoragePath = null)
     {
         return new Instance
         {
@@ -138,10 +163,10 @@ public class ContentOnDemandControllerTests
                 },
                 new DataElement
                 {
-                    Id = "3a1b2f4c-7a1e-4b25-9f0f-0d6a0f3a5b21",
+                    Id = _xmlDataGuid.ToString(),
                     DataType = "a2-xml",
                     BlobStoragePath =
-                        $"{_org}/{_app}/{_instanceGuid}/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA",
+                        xmlBlobStoragePath ?? $"{_org}/{_app}/{_instanceGuid}/data/{_xmlDataGuid}",
                     Metadata =
                     [
                         new KeyValueEntry { Key = "formid", Value = "1000" },
@@ -152,12 +177,15 @@ public class ContentOnDemandControllerTests
         };
     }
 
-    private HttpClient GetTestClient(Mock<IBlobRepository> blobRepositoryMock = null)
+    private HttpClient GetTestClient(
+        Mock<IBlobRepository> blobRepositoryMock = null,
+        string xmlBlobStoragePath = null
+    )
     {
         Mock<IInstanceRepository> instanceRepositoryMock = new();
         instanceRepositoryMock
             .Setup(ir => ir.GetOne(_instanceGuid, true, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => (GetInstance(), 1L));
+            .ReturnsAsync(() => (GetInstance(xmlBlobStoragePath), 1L));
 
         Mock<IApplicationRepository> applicationRepositoryMock = new();
         applicationRepositoryMock

--- a/test/UnitTest/TestingControllers/DataControllerTests.Get_DataElementStoredAtVersionedBlobStoragePath_ReturnsContent.verified.txt
+++ b/test/UnitTest/TestingControllers/DataControllerTests.Get_DataElementStoredAtVersionedBlobStoragePath_ReturnsContent.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  Response: {
+    Status: 200 OK,
+    Content: {
+      Headers: {
+        Content-Length: 29,
+        Content-Type: text/plain; charset=utf-8
+      },
+      Value: This is a versioned blob file
+    }
+  }
+}

--- a/test/UnitTest/TestingControllers/DataControllerTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerTests.cs
@@ -520,6 +520,58 @@ public class DataControllerTests : IClassFixture<TestApplicationFactory<DataCont
     }
 
     [Fact]
+    public async Task Get_DataElementStoredAtVersionedBlobStoragePath_ReturnsContent()
+    {
+        // Arrange
+        string dataPathWithData =
+            $"{_versionPrefix}/instances/1337/{VersionedBlobElement.InstanceGuid}/data/{VersionedBlobElement.DataElementId}";
+
+        string token = PrincipalUtil.GetToken(1337, 1337, 3);
+        HttpClient client = GetTestClient(bearerAuthToken: token);
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync(dataPathWithData);
+
+        // Assert
+        await VerifyXunit.Verifier.Verify(new { Response = response });
+    }
+
+    [Fact]
+    public async Task OverwriteData_DataElementStoredAtVersionedBlobStoragePath_Ok()
+    {
+        // Arrange
+        string dataPathWithData =
+            $"{_versionPrefix}/instances/1337/{VersionedBlobElement.InstanceGuid}/data/{VersionedBlobElement.DataElementId}";
+        HttpContent content = new StringContent("This is a blob file with updated data");
+
+        Mock<IBlobRepository> blobRepositoryMock = new();
+        blobRepositoryMock
+            .Setup(b =>
+                b.WriteBlob(
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    VersionedBlobElement.BlobStoragePath,
+                    It.IsAny<int?>()
+                )
+            )
+            .ReturnsAsync((37, DateTimeOffset.UtcNow))
+            .Verifiable();
+
+        string token = PrincipalUtil.GetToken(1337, 1337, 3);
+        HttpClient client = GetTestClient(
+            blobRepositoryMock: blobRepositoryMock,
+            bearerAuthToken: token
+        );
+
+        // Act
+        HttpResponseMessage response = await client.PutAsync(dataPathWithData, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        blobRepositoryMock.Verify();
+    }
+
+    [Fact]
     public async Task Get_DataElementDoesNotExists_ReturnsNotFound()
     {
         string dataPathWithData =
@@ -1231,6 +1283,14 @@ public class DataControllerTests : IClassFixture<TestApplicationFactory<DataCont
     {
         User,
         Org,
+    }
+
+    private static class VersionedBlobElement
+    {
+        public const string InstanceGuid = "649388f0-a2c0-4774-bd11-c870223ed819";
+        public const string DataElementId = "7d1c4b8e-3f2a-4c6d-9e5b-1a2b3c4d5e6f";
+        public const string BlobStoragePath =
+            "tdd/endring-av-navn/" + InstanceGuid + "/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA";
     }
 
     private static class SensitiveDataApp

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -131,6 +131,76 @@ public class DataControllerUnitTests
     }
 
     [Fact]
+    public async Task Get_BlobStoragePathOutsideInstance_ReturnsNotFound()
+    {
+        // Arrange
+        string blobVersionId = "AZfQZ9nHc0eLm4Xv2R1qAA";
+        Mock<IBlobRepository> blobRepositoryMock = new();
+        (DataController testController, _) = GetTestController(
+            ["/isRead"],
+            blobStoragePath: $"{_appId}/{Guid.NewGuid()}/data-elements/{blobVersionId}",
+            blobRepositoryMock: blobRepositoryMock
+        );
+
+        // Act
+        var result = await testController.Get(
+            _instanceOwnerPartyId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+        blobRepositoryMock.Verify(
+            b =>
+                b.ReadBlob(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task OverwriteData_BlobStoragePathOutsideInstance_ReturnsInternalServerError()
+    {
+        // Arrange
+        string blobVersionId = "AZfQZ9nHc0eLm4Xv2R1qAA";
+        Mock<IBlobRepository> blobRepositoryMock = new();
+        (DataController testController, _) = GetTestController(
+            [],
+            includeRequestBody: true,
+            blobStoragePath: $"{_appId}/{Guid.NewGuid()}/data-elements/{blobVersionId}",
+            blobRepositoryMock: blobRepositoryMock
+        );
+
+        // Act
+        var result = await testController.OverwriteData(
+            _instanceOwnerPartyId,
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            CancellationToken.None
+        );
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
+        blobRepositoryMock.Verify(
+            b =>
+                b.WriteBlob(
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int?>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
     public async Task Update_VerifyDataRepositoryUpdateInput()
     {
         // Arrange
@@ -301,10 +371,15 @@ public class DataControllerUnitTests
     private (
         DataController TestController,
         Mock<IDataRepository> DataRepositoryMock
-    ) GetTestController(List<string> expectedPropertiesForPatch, bool includeRequestBody = false)
+    ) GetTestController(
+        List<string> expectedPropertiesForPatch,
+        bool includeRequestBody = false,
+        string blobStoragePath = null,
+        Mock<IBlobRepository> blobRepositoryMock = null
+    )
     {
         Mock<IDataRepository> dataRepositoryMock = new();
-        Mock<IBlobRepository> blobRepositoryMock = new();
+        blobRepositoryMock ??= new();
         Mock<IInstanceRepository> instanceRepositoryMock = new();
         Mock<IApplicationRepository> applicationRepositoryMock = new();
         Mock<IInstanceEventService> instanceEventServiceMock = new();
@@ -339,7 +414,8 @@ public class DataControllerUnitTests
                         DataType = _dataType,
                         IsRead = false,
                         ContentType = "application/octet-stream",
-                        BlobStoragePath = $"ttd/apps-test/{instanceGuid}/data/{dataElementId}",
+                        BlobStoragePath =
+                            blobStoragePath ?? $"ttd/apps-test/{instanceGuid}/data/{dataElementId}",
                     }
             );
 

--- a/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
+++ b/test/UnitTest/TestingControllers/DataControllerUnitTests.cs
@@ -142,16 +142,16 @@ public class DataControllerUnitTests
             blobRepositoryMock: blobRepositoryMock
         );
 
-        // Act
-        var result = await testController.Get(
-            _instanceOwnerPartyId,
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            CancellationToken.None
+        // Act & assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            testController.Get(
+                _instanceOwnerPartyId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                CancellationToken.None
+            )
         );
 
-        // Assert
-        Assert.IsType<NotFoundObjectResult>(result);
         blobRepositoryMock.Verify(
             b =>
                 b.ReadBlob(
@@ -177,17 +177,16 @@ public class DataControllerUnitTests
             blobRepositoryMock: blobRepositoryMock
         );
 
-        // Act
-        var result = await testController.OverwriteData(
-            _instanceOwnerPartyId,
-            Guid.NewGuid(),
-            Guid.NewGuid(),
-            CancellationToken.None
+        // Act & assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            testController.OverwriteData(
+                _instanceOwnerPartyId,
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                CancellationToken.None
+            )
         );
 
-        // Assert
-        var objectResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(StatusCodes.Status500InternalServerError, objectResult.StatusCode);
         blobRepositoryMock.Verify(
             b =>
                 b.WriteBlob(

--- a/test/UnitTest/data/blob/tdd/endring-av-navn/649388f0-a2c0-4774-bd11-c870223ed819/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA
+++ b/test/UnitTest/data/blob/tdd/endring-av-navn/649388f0-a2c0-4774-bd11-c870223ed819/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA
@@ -1,0 +1,1 @@
+This is a versioned blob file

--- a/test/UnitTest/data/postgresdata/dataelements/7d1c4b8e-3f2a-4c6d-9e5b-1a2b3c4d5e6f.json
+++ b/test/UnitTest/data/postgresdata/dataelements/7d1c4b8e-3f2a-4c6d-9e5b-1a2b3c4d5e6f.json
@@ -1,0 +1,15 @@
+{
+  "id": "7d1c4b8e-3f2a-4c6d-9e5b-1a2b3c4d5e6f",
+  "instanceGuid": "649388f0-a2c0-4774-bd11-c870223ed819",
+  "dataType": "default",
+  "contentType": "text/plain; charset=utf-8",
+  "blobStoragePath": "tdd/endring-av-navn/649388f0-a2c0-4774-bd11-c870223ed819/data-elements/AZfQZ9nHc0eLm4Xv2R1qAA",
+  "size": 29,
+  "locked": false,
+  "refs": [
+  ],
+  "created": "2020-05-11T17:09:28.4621953Z",
+  "lastChanged": "2020-05-11T17:09:28.4621953Z",
+  "lastChangedBy": "123",
+  "isRead": false
+}


### PR DESCRIPTION
Lets this build read and overwrite data element content written by a build with blob versioning enabled, so that a rollout of that build can be rolled back to this one after versioned content exists.

Content this build writes lives at `{appId}/{instanceGuid}/data/{dataElementId}`, while the versioning build writes `{appId}/{instanceGuid}/data-elements/{blobVersionId}`. The content GET and PUT in `DataController` both recomputed the legacy path and refused to act unless the stored `blobStoragePath` equaled it, so they answered 404 and 500 for versioned content. Both now accept either shape and use the stored path.

`ContentOnDemandController` composed a legacy path of its own for the signature, payment and form data blobs it renders, ignoring the stored `blobStoragePath`. The versioning build's A2 migration stores every element that carries a blob at a versioned path, so those three reads would have failed for A2 instances migrated by it. They now read the stored path, which is where the blob is under either build. `DataService.GenerateSha256Hash` and `SigningService` already did.

The path is matched by shape rather than against the stored blob version, which this build cannot see: `currentblobversion` is a column that none of this build's SQL functions select, and it is deliberately absent from the element JSONB.

PUT overwrites the versioned blob in place instead of writing the legacy path and moving the element back to it. The blob version tables carry no content metadata, so overwriting keeps the element's path, `currentblobversion` and `dataelementblobversions` rows consistent, which is the state the versioning build expects when rolled forward again. Moving the element back would need that row state cleared as well, which none of this build's SQL functions can do, and would leave both the legacy blob and the still-attached versioned blob behind.

Content addressed by a blob version id is therefore no longer immutable. That only weakens content ETags issued by the versioning build, which this build neither issues nor honours, and which are unenforceable during a rollback anyway.

Immediate delete is deliberately left as it is. `DataService.DeleteImmediately` still deletes the recomputed legacy path, so deleting a versioned element removes the metadata and silently leaves the blob behind. The `deletedataelement_v2` function from #1049 detaches the element's `dataelementblobversions` rows, so `readorphanblobversionsforcleanup` reclaims the blob once the versioning build runs again.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Data stored at versioned blob paths can now be read and updated correctly.
  * Signature, payment, and form data use their recorded storage paths.
  * Invalid or unrelated storage paths are rejected safely without accessing blob content.
  * Prevented access to data stored outside the expected application instance.

* **Tests**
  * Added coverage for versioned blob retrieval, updates, form-data rendering, and invalid paths.
  * Added regression tests for rejecting malformed, nested, and unrelated storage paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->