### PR TITLE
fix: update CleanupController route to support appId with slashes

### DIFF
--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -104,7 +104,9 @@ public class CleanupController(
     {
         if (string.IsNullOrWhiteSpace(appId))
         {
-            return BadRequest("AppId cannot be empty");
+            return BadRequest(
+                "AppId cannot be null, empty or consist only of white-space characters"
+            );
         }
 
         int successfullyDeleted = 0;

--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -94,7 +94,7 @@ public class CleanupController(
     /// Invoke periodic cleanup of instances for a specific app
     /// </summary>
     /// <returns>?</returns>
-    [HttpDelete("cleanupinstancesforapp/{appId}")]
+    [HttpDelete("cleanupinstancesforapp/{**appId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult> CleanupInstancesForApp(

--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -94,21 +94,15 @@ public class CleanupController(
     /// Invoke periodic cleanup of instances for a specific app
     /// </summary>
     /// <returns>?</returns>
-    [HttpDelete("cleanupinstancesforapp/{**appId}")]
+    [HttpDelete("cleanupinstancesforapp/{org}/{app}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ApiExplorerSettings(IgnoreApi = true)]
     public async Task<ActionResult> CleanupInstancesForApp(
-        string appId,
+        string org,
+        string app,
         CancellationToken cancellationToken
     )
     {
-        if (string.IsNullOrWhiteSpace(appId))
-        {
-            return BadRequest(
-                "AppId cannot be null, empty or consist only of white-space characters"
-            );
-        }
-
         int successfullyDeleted = 0;
         int processed = 0;
         InstanceQueryResponse instancesResponse = new() { ContinuationToken = null };
@@ -119,7 +113,7 @@ public class CleanupController(
             InstanceQueryParameters queryParameters = new()
             {
                 Size = 5000,
-                AppId = appId,
+                AppId = $"{org}/{app}",
                 ContinuationToken = instancesResponse.ContinuationToken,
             };
 

--- a/src/Storage/Controllers/CleanupController.cs
+++ b/src/Storage/Controllers/CleanupController.cs
@@ -102,6 +102,11 @@ public class CleanupController(
         CancellationToken cancellationToken
     )
     {
+        if (string.IsNullOrWhiteSpace(appId))
+        {
+            return BadRequest("AppId cannot be empty");
+        }
+
         int successfullyDeleted = 0;
         int processed = 0;
         InstanceQueryResponse instancesResponse = new() { ContinuationToken = null };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
cleanupinstancesforapp now support appId with slashes

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the cleanup endpoint to accept application identifiers using separate organization and application path segments.
  * Existing cleanup behavior, including processing across pages, remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->