### PR TITLE
fix: comment out alter table commands

### DIFF
--- a/src/Storage/Migration/v0.34/00-create-blob-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-blob-versioning.sql
@@ -1,5 +1,5 @@
-ALTER TABLE storage.dataelements
-ADD COLUMN IF NOT EXISTS currentblobversion UUID NULL;
+-- ALTER TABLE storage.dataelements
+-- ADD COLUMN IF NOT EXISTS currentblobversion UUID NULL;
 
 CREATE TABLE IF NOT EXISTS storage.dataelementblobversions (
     id UUID PRIMARY KEY,

--- a/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
@@ -1,5 +1,5 @@
-ALTER TABLE storage.instances
-ADD COLUMN IF NOT EXISTS instance_version INT NOT NULL DEFAULT 1;
+-- ALTER TABLE storage.instances
+-- ADD COLUMN IF NOT EXISTS instance_version INT NOT NULL DEFAULT 1;
 
-ALTER TABLE storage.instances
-ADD COLUMN IF NOT EXISTS process_state_version INT NOT NULL DEFAULT 1;
+-- ALTER TABLE storage.instances
+-- ADD COLUMN IF NOT EXISTS process_state_version INT NOT NULL DEFAULT 1;


### PR DESCRIPTION
## Description
Comment out alter table requests so they can be done safely before migration is applied. Then later uncomment the lines of code for tests.

Tests will fail on this PR. Its meant as a stand alone for deployment.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
