### PR TITLE
fix: migration script, inline function for if check

### DIFF
--- a/src/Storage/Migration/v0.34/00-create-blob-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-blob-versioning.sql
@@ -1,5 +1,15 @@
-ALTER TABLE storage.dataelements
-ADD COLUMN IF NOT EXISTS currentblobversion UUID NULL;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_attribute
+        WHERE attrelid = 'storage.dataelements'::regclass
+          AND attname = 'currentblobversion'
+          AND attnum > 0 AND NOT attisdropped
+    ) THEN
+        ALTER TABLE storage.dataelements
+        ADD COLUMN IF NOT EXISTS currentblobversion UUID NULL;
+    END IF;
+END $$;
 
 CREATE TABLE IF NOT EXISTS storage.dataelementblobversions (
     id UUID PRIMARY KEY,

--- a/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
@@ -7,7 +7,7 @@ BEGIN
           AND attnum > 0 AND NOT attisdropped
     ) THEN
         ALTER TABLE storage.instances
-        ADD COLUMN instance_version INT NOT NULL DEFAULT 1;
+        ADD COLUMN IF NOT EXISTS instance_version INT NOT NULL DEFAULT 1;
     END IF;
 
     IF NOT EXISTS (
@@ -17,6 +17,6 @@ BEGIN
           AND attnum > 0 AND NOT attisdropped
     ) THEN
         ALTER TABLE storage.instances
-        ADD COLUMN process_state_version INT NOT NULL DEFAULT 1;
+        ADD COLUMN IF NOT EXISTS process_state_version INT NOT NULL DEFAULT 1;
     END IF;
-END $$;
+END $$;ß

--- a/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
@@ -19,4 +19,4 @@ BEGIN
         ALTER TABLE storage.instances
         ADD COLUMN IF NOT EXISTS process_state_version INT NOT NULL DEFAULT 1;
     END IF;
-END $$;ß
+END $$;

--- a/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
+++ b/src/Storage/Migration/v0.34/00-create-instance-versioning.sql
@@ -1,5 +1,22 @@
-ALTER TABLE storage.instances
-ADD COLUMN IF NOT EXISTS instance_version INT NOT NULL DEFAULT 1;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_attribute
+        WHERE attrelid = 'storage.instances'::regclass
+          AND attname = 'instance_version'
+          AND attnum > 0 AND NOT attisdropped
+    ) THEN
+        ALTER TABLE storage.instances
+        ADD COLUMN instance_version INT NOT NULL DEFAULT 1;
+    END IF;
 
-ALTER TABLE storage.instances
-ADD COLUMN IF NOT EXISTS process_state_version INT NOT NULL DEFAULT 1;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_attribute
+        WHERE attrelid = 'storage.instances'::regclass
+          AND attname = 'process_state_version'
+          AND attnum > 0 AND NOT attisdropped
+    ) THEN
+        ALTER TABLE storage.instances
+        ADD COLUMN process_state_version INT NOT NULL DEFAULT 1;
+    END IF;
+END $$;


### PR DESCRIPTION
## Description
Fix, wrap `ALTER TABLE` command in an inline function with if check for the attribute existing.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by checking whether versioning columns already exist before adding them.
  * Prevented migration errors when partially applied or previously completed migrations are run again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->